### PR TITLE
Om/dev/bugfix/linkoptionlable

### DIFF
--- a/lib/src/services/link_option_service.dart
+++ b/lib/src/services/link_option_service.dart
@@ -49,7 +49,6 @@ class LinkOptionService {
     }
 
     final titleField = await _getTitleField(doctype);
-    final isChildDoctype = await _isChildDoctype(doctype);
 
     List<dynamic> documents;
     try {
@@ -224,12 +223,6 @@ class LinkOptionService {
     } catch (_) {
       return null;
     }
-  }
-
-  /// Check if a doctype is a child table (istable=1) from cached metadata.
-  Future<bool> _isChildDoctype(String doctype) async {
-    final meta = await _getDocTypeMeta(doctype);
-    return meta?.isTable ?? false;
   }
 
   void clearAllCache() {

--- a/lib/src/services/link_option_service.dart
+++ b/lib/src/services/link_option_service.dart
@@ -1,6 +1,10 @@
 import 'dart:convert';
 import '../api/client.dart';
+import '../database/app_database.dart';
 import '../database/entities/link_option_entity.dart';
+import '../models/doc_type_meta.dart';
+import 'meta_service.dart';
+import '../utils/depends_on_evaluator.dart';
 
 const int _kLinkOptionCacheMaxEntries = 30;
 
@@ -11,6 +15,9 @@ class LinkOptionService {
   final List<String> _cacheKeys = [];
 
   LinkOptionService(this._client);
+
+  /// Cache of doctype -> title_field name, populated lazily from DB metadata.
+  final Map<String, String?> _titleFieldCache = {};
 
   String _cacheKey(String doctype, List<List<dynamic>>? filters) {
     if (filters == null || filters.isEmpty) return doctype;
@@ -41,6 +48,9 @@ class LinkOptionService {
       return _memoryCache[key]!;
     }
 
+    final titleField = await _getTitleField(doctype);
+    final isChildDoctype = await _isChildDoctype(doctype);
+
     List<dynamic> documents;
     try {
       documents = await _client.doctype.list(
@@ -51,7 +61,6 @@ class LinkOptionService {
     } catch (_) {
       return [];
     }
-
     final now = DateTime.now().millisecondsSinceEpoch;
     final linkOptions = <LinkOptionEntity>[];
 
@@ -61,6 +70,15 @@ class LinkOptionService {
       final name = docMap['name'] as String? ?? '';
       if (name.isEmpty) continue;
       String? label;
+
+      // Determine the display label for the link option
+      // First try the title field if it exists and has a value
+      if (titleField != null &&
+          docMap[titleField] != null &&
+          docMap[titleField].toString().trim().isNotEmpty) {
+        label = docMap[titleField].toString();
+      }
+      // Fall back to common label fields if title field is not available or empty
       for (final k in [
         'title',
         'full_name',
@@ -68,11 +86,13 @@ class LinkOptionService {
         'supplier_name',
         'label',
       ]) {
+        if (label != null && label.isNotEmpty) break;
         if (docMap.containsKey(k) && docMap[k] != null) {
           label = docMap[k].toString();
           break;
         }
       }
+      // Default to the document name if no label is found
       label ??= name;
       linkOptions.add(
         LinkOptionEntity(
@@ -115,7 +135,8 @@ class LinkOptionService {
   }
 
   /// Returns field names that are dependencies in link_filters (eval:doc.xxx).
-  /// e.g. [["District","state","=","eval:doc.state"]] -> ["state"]
+  /// Handles both `eval:doc.state` and `eval: doc.state` (Frappe standard format).
+  /// e.g. [["District","state","=","eval: doc.state"]] -> ["state"]
   static List<String> getDependentFieldNames(String? linkFiltersJson) {
     if (linkFiltersJson == null || linkFiltersJson.isEmpty) return [];
     try {
@@ -125,11 +146,11 @@ class LinkOptionService {
           : <dynamic>[];
       final names = <String>[];
       for (final filter in filters) {
-        if (filter.length < 4) continue;
+        if (filter is! List || filter.length < 4) continue;
         final value = filter[3];
-        if (value is String && value.startsWith('eval:doc.')) {
-          final fieldName = value.substring(9).trim();
-          if (fieldName.isNotEmpty && !names.contains(fieldName)) {
+        if (value is String) {
+          final fieldName = DependsOnEvaluator.extractEvalDocField(value);
+          if (fieldName != null && !names.contains(fieldName)) {
             names.add(fieldName);
           }
         }
@@ -141,7 +162,8 @@ class LinkOptionService {
   }
 
   /// Parse Frappe link_filters and build API filters.
-  /// Frappe format: [["District","state","=","eval:doc.state"]]
+  /// Frappe format: [["District","state","=","eval: doc.state"]]
+  /// Handles both `eval:doc.x` and `eval: doc.x` (Frappe standard format).
   /// API get_list accepts: [["DocType", "field", "operator", value]] (4 elements).
   static List<List<dynamic>>? parseLinkFilters(
     String? linkFiltersJson,
@@ -155,12 +177,14 @@ class LinkOptionService {
           : <dynamic>[];
       final result = <List<dynamic>>[];
       for (final filter in filters) {
-        if (filter.length < 4) continue;
+        if (filter is! List || filter.length < 4) continue;
         dynamic value = filter[3];
-        if (value is String && value.startsWith('eval:doc.')) {
-          final fieldName = value.substring(9).trim();
-          value = formData[fieldName];
-          if (value == null || value == '') continue;
+        if (value is String) {
+          final fieldName = DependsOnEvaluator.extractEvalDocField(value);
+          if (fieldName != null) {
+            value = formData[fieldName];
+            if (value == null || value == '') continue;
+          }
         }
         result.add([filter[0], filter[1], filter[2], value]);
       }
@@ -177,10 +201,40 @@ class LinkOptionService {
         _cacheKeys.remove(k);
       }
     }
+    _titleFieldCache.remove(doctype);
+  }
+
+  //get title field from docType db. API if online.
+  Future<String?> _getTitleField(String doctype) async {
+    if (_titleFieldCache.containsKey(doctype)) {
+      return _titleFieldCache[doctype];
+    }
+
+    final meta = await _getDocTypeMeta(doctype);
+    final titleField = meta?.titleField;
+    _titleFieldCache[doctype] = titleField;
+    return titleField;
+  }
+
+  Future<DocTypeMeta?> _getDocTypeMeta(String doctype) async {
+    try {
+      final database = await AppDatabase.getInstance();
+      final metaService = MetaService(_client, database);
+      return await metaService.getMeta(doctype);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Check if a doctype is a child table (istable=1) from cached metadata.
+  Future<bool> _isChildDoctype(String doctype) async {
+    final meta = await _getDocTypeMeta(doctype);
+    return meta?.isTable ?? false;
   }
 
   void clearAllCache() {
     _memoryCache.clear();
     _cacheKeys.clear();
+    _titleFieldCache.clear();
   }
 }

--- a/lib/src/services/link_option_service.dart
+++ b/lib/src/services/link_option_service.dart
@@ -54,6 +54,7 @@ class LinkOptionService {
     try {
       documents = await _client.doctype.list(
         doctype,
+        fields: ['*'],
         filters: normalizedFilters,
         limitPageLength: 1000,
       );

--- a/lib/src/ui/widgets/form_builder.dart
+++ b/lib/src/ui/widgets/form_builder.dart
@@ -438,6 +438,9 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
                   getMeta: widget.getMeta,
                   fileUrlBase: widget.fileUrlBase,
                   imageHeaders: widget.imageHeaders,
+                  // link option service for child doctype.
+                  linkOptionService: widget.linkOptionService,
+                  // fetch linked document for child doctype.
                   fetchLinkedDocument: widget.fetchLinkedDocument,
                   translate: widget.translate,
                   onButtonPressed: widget.onButtonPressed,
@@ -467,9 +470,10 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
             for (final otherField in widget.meta.fields) {
               if (otherField.fieldtype == 'Link' &&
                   otherField.linkFilters != null &&
-                  otherField.linkFilters!.contains(
-                    'eval:doc.${field.fieldname}',
-                  )) {
+                  // Check if other field's link filters depend on this field ignoring spaces
+                  RegExp(
+                    'eval\\s*:\\s*doc\\.${field.fieldname}',
+                  ).hasMatch(otherField.linkFilters ?? "")) {
                 _formData.remove(otherField.fieldname);
               }
             }

--- a/lib/src/utils/depends_on_evaluator.dart
+++ b/lib/src/utils/depends_on_evaluator.dart
@@ -120,6 +120,17 @@ class DependsOnEvaluator {
     return expr;
   }
 
+  /// Extract `doc.fieldname` from an eval expression like `eval:doc.x` or `eval: doc.x`.
+  /// Returns the field name, or null if the value is not an eval:doc expression.
+  static String? extractEvalDocField(String value) {
+    String expr = value.trim();
+    if (value.startsWith('eval:')) {
+      expr = value.substring(5).trimLeft();
+    }
+    String fieldName = _extractFieldName(expr);
+    return expr == fieldName ? null : fieldName;
+  }
+
   static dynamic _extractValue(String expr) {
     expr = expr.trim();
     // Remove quotes if present


### PR DESCRIPTION
Fix Link Field Label Resolution and Filter Parsing
Summary
This PR improves link field label resolution by utilizing DocType metadata's title_field property and enhances link filter parsing to handle Frappe's standard format variations.

Changes Made
🔧 Link Field Label Resolution

Enhanced LinkOptionService to fetch and cache the title_field from DocType metadata for accurate label display
Implemented proper label hierarchy: title_field → common label fields → document name
Added metadata caching to improve performance
🔧 Link Filter Parsing Improvements

Added support for both eval:doc.x and eval: doc.x formats (Frappe standard)
Introduced extractEvalDocField utility method for consistent eval expression parsing
Updated dependent field detection using regex pattern matching for robustness
🔧 Form Builder Updates

Enhanced child doctype handling with link option service integration
Improved field dependency detection with space-tolerant regex matching
Files Modified
lib/src/services/link_option_service.dart - Core link option improvements
lib/src/ui/widgets/form_builder.dart - Form builder dependency detection
lib/src/utils/depends_on_evaluator.dart - Utility method for eval parsing
Testing
The changes maintain backward compatibility while fixing label resolution issues and improving filter parsing reliability.