### PR TITLE
enhance mobile home support

### DIFF
--- a/lib/frappe_mobile_sdk.dart
+++ b/lib/frappe_mobile_sdk.dart
@@ -54,6 +54,9 @@ export 'src/services/offline_repository.dart';
 export 'src/services/link_option_service.dart';
 export 'src/services/workflow_service.dart';
 
+// Screens
+export 'src/screens/mobile_home_screen.dart';
+
 // UI Components
 export 'src/ui/app_guard.dart';
 export 'src/ui/login_screen.dart';

--- a/lib/src/api/doctype_service.dart
+++ b/lib/src/api/doctype_service.dart
@@ -51,6 +51,41 @@ class DoctypeService {
     return [];
   }
 
+  /// Lists child doctype records with ALL fields.
+  /// get_list and reportview only return standard fields for child doctypes.
+  /// This fetches names first, then batch-loads full docs via /api/resource.
+  Future<List<Map<String, dynamic>>> listChildDocs(
+    String doctype, {
+    List<List<dynamic>>? filters,
+    int limitPageLength = 1000,
+  }) async {
+    // Step 1: get names (get_list works for this)
+    final nameList = await list(
+      doctype,
+      fields: ['name'],
+      filters: filters,
+      limitPageLength: limitPageLength,
+    );
+    if (nameList.isEmpty) return [];
+
+    // Step 2: batch-fetch full documents via /api/resource/{doctype}/{name}
+    final docs = <Map<String, dynamic>>[];
+    const batchSize = 50;
+    for (var i = 0; i < nameList.length; i += batchSize) {
+      final batch = nameList.skip(i).take(batchSize);
+      final futures = batch.map((n) {
+        final name = n is Map<String, dynamic>
+            ? n['name']?.toString() ?? ''
+            : '';
+        if (name.isEmpty) return Future.value(<String, dynamic>{});
+        return getByName(doctype, name);
+      });
+      final results = await Future.wait(futures);
+      docs.addAll(results.where((d) => d.isNotEmpty));
+    }
+    return docs;
+  }
+
   Future<Map<String, dynamic>> getByName(String doctype, String name) async {
     final response = await _restHelper.get('/api/resource/$doctype/$name');
     if (response is Map<String, dynamic> && response.containsKey('data')) {

--- a/lib/src/database/app_database.dart
+++ b/lib/src/database/app_database.dart
@@ -93,6 +93,7 @@ class AppDatabase {
       version: _version,
       onCreate: _onCreate,
       onConfigure: _onConfigure,
+      onUpgrade: _onUpgrade,
     );
     return AppDatabase._(database);
   }

--- a/lib/src/database/app_database.dart
+++ b/lib/src/database/app_database.dart
@@ -8,7 +8,7 @@ import 'daos/auth_token_dao.dart';
 import 'daos/doctype_permission_dao.dart';
 
 class AppDatabase {
-  static const int _version = 1;
+  static const int _version = 2;
   static Database? _database;
   static AppDatabase? _instance;
   static String? _databaseName;
@@ -78,6 +78,7 @@ class AppDatabase {
         version: _version,
         onCreate: _onCreate,
         onConfigure: _onConfigure,
+        onUpgrade: _onUpgrade,
       );
     }
 
@@ -94,6 +95,14 @@ class AppDatabase {
       onConfigure: _onConfigure,
     );
     return AppDatabase._(database);
+  }
+
+  /// Migrate database schema on upgrade
+  static Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute('ALTER TABLE doctype_meta ADD COLUMN groupName TEXT');
+      await db.execute('ALTER TABLE doctype_meta ADD COLUMN sortOrder INTEGER');
+    }
   }
 
   /// Configure database (enable foreign keys)
@@ -131,7 +140,9 @@ class AppDatabase {
         modified TEXT,
         serverModifiedAt TEXT,
         isMobileForm INTEGER NOT NULL DEFAULT 0,
-        metaJson TEXT NOT NULL
+        metaJson TEXT NOT NULL,
+        groupName TEXT,
+        sortOrder INTEGER
       )
     ''');
 

--- a/lib/src/database/app_database.dart
+++ b/lib/src/database/app_database.dart
@@ -86,7 +86,8 @@ class AppDatabase {
     return _instance!;
   }
 
-  /// Create in-memory database for testing
+  /// Create in-memory database for testing.
+  /// Each call returns a fresh isolated database (singleInstance: false).
   static Future<AppDatabase> inMemoryDatabase() async {
     final database = await openDatabase(
       inMemoryDatabasePath,
@@ -94,6 +95,7 @@ class AppDatabase {
       onCreate: _onCreate,
       onConfigure: _onConfigure,
       onUpgrade: _onUpgrade,
+      singleInstance: false,
     );
     return AppDatabase._(database);
   }

--- a/lib/src/database/daos/doctype_meta_dao.dart
+++ b/lib/src/database/daos/doctype_meta_dao.dart
@@ -38,6 +38,7 @@ class DoctypeMetaDao {
       'doctype_meta',
       where: 'isMobileForm = ?',
       whereArgs: [1],
+      orderBy: 'sortOrder ASC',
     );
     return maps.map((map) => DoctypeMetaEntity.fromDb(map)).toList();
   }

--- a/lib/src/database/entities/doctype_meta_entity.dart
+++ b/lib/src/database/entities/doctype_meta_entity.dart
@@ -17,12 +17,20 @@ class DoctypeMetaEntity {
   /// Full metadata JSON stored as text
   final String metaJson;
 
+  /// Group name for organizing doctypes on home screen
+  final String? groupName;
+
+  /// Sort order within the group
+  final int? sortOrder;
+
   DoctypeMetaEntity({
     required this.doctype,
     this.modified,
     this.serverModifiedAt,
     this.isMobileForm = false,
     required this.metaJson,
+    this.groupName,
+    this.sortOrder,
   });
 
   /// Convert from database map
@@ -33,6 +41,8 @@ class DoctypeMetaEntity {
       serverModifiedAt: map['serverModifiedAt'] as String?,
       isMobileForm: (map['isMobileForm'] as int? ?? 0) == 1,
       metaJson: map['metaJson'] as String,
+      groupName: map['groupName'] as String?,
+      sortOrder: map['sortOrder'] as int?,
     );
   }
 
@@ -44,6 +54,8 @@ class DoctypeMetaEntity {
       'serverModifiedAt': serverModifiedAt,
       'isMobileForm': isMobileForm ? 1 : 0,
       'metaJson': metaJson,
+      'groupName': groupName,
+      'sortOrder': sortOrder,
     };
   }
 }

--- a/lib/src/screens/mobile_home_screen.dart
+++ b/lib/src/screens/mobile_home_screen.dart
@@ -1,0 +1,255 @@
+// ignore_for_file: use_build_context_synchronously
+import 'package:flutter/material.dart';
+import '../sdk/frappe_sdk.dart';
+import '../ui/document_list_screen.dart';
+
+/// Generic home screen that renders doctype groups from the SDK's Mobile Configuration.
+class MobileHomeScreen extends StatefulWidget {
+  final FrappeSDK sdk;
+  final String appTitle;
+  final Future<void> Function()? onLogout;
+
+  const MobileHomeScreen({
+    super.key,
+    required this.sdk,
+    required this.appTitle,
+    this.onLogout,
+  });
+
+  @override
+  State<MobileHomeScreen> createState() => _MobileHomeScreenState();
+}
+
+class _MobileHomeScreenState extends State<MobileHomeScreen> {
+  Map<String, List<String>> _groups = {};
+  Map<String, int> _counts = {};
+  Map<String, int> _dirtyCounts = {};
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    setState(() => _loading = true);
+    try {
+      final groups = await widget.sdk.meta.getMobileFormGroups();
+      final counts = <String, int>{};
+      final dirtyCounts = <String, int>{};
+
+      for (final doctype in groups.values.expand((l) => l)) {
+        try {
+          final docs = await widget.sdk.repository.getDocumentsByDoctype(doctype);
+          counts[doctype] = docs.length;
+          dirtyCounts[doctype] = docs.where((d) => d.status == 'dirty').length;
+        } catch (_) {
+          counts[doctype] = 0;
+          dirtyCounts[doctype] = 0;
+        }
+      }
+
+      if (mounted) {
+        setState(() {
+          _groups = groups;
+          _counts = counts;
+          _dirtyCounts = dirtyCounts;
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _navigateToDoctype(String doctype) async {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Loading...')),
+    );
+    try {
+      final meta = await widget.sdk.meta.getMeta(doctype);
+      final docs = await widget.sdk.repository.getDocumentsByDoctype(doctype);
+      try {
+        await widget.sdk.sync.pullSync(doctype: doctype);
+      } catch (_) {}
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        await Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => DocumentListScreen(
+              doctype: doctype,
+              meta: meta,
+              repository: widget.sdk.repository,
+              syncService: widget.sdk.sync,
+              metaService: widget.sdk.meta,
+              linkOptionService: widget.sdk.linkOptions,
+              api: widget.sdk.api,
+              getMobileUuid: () async => '',
+              initialDocuments: docs,
+              userRoles: widget.sdk.roles,
+              permissionService: widget.sdk.permissions,
+              translate: (s) => widget.sdk.translations.translate(s),
+            ),
+          ),
+        );
+        _load();
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).hideCurrentSnackBar();
+        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+          content: Text('Error: ${e.toString().split(':').last.trim()}'),
+          backgroundColor: Colors.red,
+        ));
+      }
+    }
+  }
+
+  Future<void> _handleLogout() async {
+    if (widget.onLogout != null) {
+      await widget.onLogout!();
+    } else {
+      await widget.sdk.logout();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.appTitle),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
+            onPressed: _handleLogout,
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _loading
+            ? const Center(child: Text('Loading...'))
+            : _groups.isEmpty
+                ? _buildEmptyState()
+                : _buildGroupedList(),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return SingleChildScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: SizedBox(
+        height: 300,
+        child: const Center(
+          child: Text(
+            'No forms configured.\nPull down to refresh.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Colors.grey),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildGroupedList() {
+    return ListView(
+      children: _groups.entries.map((entry) {
+        final groupName = entry.key;
+        final doctypes = entry.value;
+        final formsCount = doctypes.length;
+
+        return ExpansionTile(
+          initiallyExpanded: true,
+          backgroundColor: const Color(0xFFB2DFDB),
+          collapsedBackgroundColor: const Color(0xFFB2DFDB),
+          shape: const Border(left: BorderSide(color: Color(0xFF00796B), width: 4)),
+          collapsedShape: const Border(left: BorderSide(color: Color(0xFF00796B), width: 4)),
+          title: Row(
+            children: [
+              Text(
+                groupName,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w800,
+                  color: Color(0xFF004D40),
+                  fontSize: 13,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 2),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF00796B),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '$formsCount ${formsCount == 1 ? 'form' : 'forms'}',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 9,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 0.3,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          children: doctypes.map((doctype) => _buildDoctypeTile(doctype)).toList(),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildDoctypeTile(String doctype) {
+    final count = _counts[doctype] ?? 0;
+    final dirty = _dirtyCounts[doctype] ?? 0;
+
+    final String subtitle;
+    final Color subtitleColor;
+    if (dirty > 0) {
+      subtitle = '↑ $dirty unsynced';
+      subtitleColor = const Color(0xFFE65100);
+    } else if (count > 0) {
+      subtitle = '✓ all synced';
+      subtitleColor = const Color(0xFF388E3C);
+    } else {
+      subtitle = 'No records yet';
+      subtitleColor = Colors.grey;
+    }
+
+    final chipColor = count > 0 ? const Color(0xFFE0F2F1) : const Color(0xFFF5F5F5);
+    final chipTextColor = count > 0 ? const Color(0xFF00796B) : Colors.grey;
+
+    return ListTile(
+      title: Text(
+        doctype,
+        style: const TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          color: Color(0xFF212121),
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: TextStyle(fontSize: 10, color: subtitleColor, fontWeight: FontWeight.w500),
+      ),
+      trailing: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
+        decoration: BoxDecoration(
+          color: chipColor,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Text(
+          '$count',
+          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700, color: chipTextColor),
+        ),
+      ),
+      onTap: () => _navigateToDoctype(doctype),
+    );
+  }
+}

--- a/lib/src/screens/mobile_home_screen.dart
+++ b/lib/src/screens/mobile_home_screen.dart
@@ -4,46 +4,96 @@ import '../sdk/frappe_sdk.dart';
 import '../ui/document_list_screen.dart';
 
 /// Generic home screen that renders doctype groups from the SDK's Mobile Configuration.
+///
+/// All colors are derived from [Theme.of(context).colorScheme]. Consuming apps
+/// control appearance by providing a [ThemeData] with a custom [ColorScheme].
 class MobileHomeScreen extends StatefulWidget {
   final FrappeSDK sdk;
   final String appTitle;
+
+  /// Called after the SDK completes logout. Use this to update your app's
+  /// auth state (e.g. `setState(() => _isAuthenticated = false)`).
   final Future<void> Function()? onLogout;
+
+  /// Optional callback when sync button is pressed. If null, default
+  /// push+pull sync is performed.
+  final Future<void> Function()? onSyncPressed;
+
+  /// Optional builder to replace the default group header.
+  /// Renders inside the tinted header row of each group card.
+  final Widget Function(BuildContext context, String groupName, int formsCount)?
+      groupHeaderBuilder;
+
+  /// Optional builder to replace the default doctype tile.
+  /// Renders as a child in a Column with dividers (no need to add dividers).
+  final Widget Function(
+          BuildContext context, String doctype, int count, int dirtyCount)?
+      tileBuilder;
 
   const MobileHomeScreen({
     super.key,
     required this.sdk,
     required this.appTitle,
     this.onLogout,
+    this.onSyncPressed,
+    this.groupHeaderBuilder,
+    this.tileBuilder,
   });
 
   @override
   State<MobileHomeScreen> createState() => _MobileHomeScreenState();
 }
 
-class _MobileHomeScreenState extends State<MobileHomeScreen> {
+class _MobileHomeScreenState extends State<MobileHomeScreen>
+    with SingleTickerProviderStateMixin {
   Map<String, List<String>> _groups = {};
   Map<String, int> _counts = {};
   Map<String, int> _dirtyCounts = {};
   bool _loading = true;
+  bool _isSyncing = false;
+  bool _isOnline = false;
+
+  late final AnimationController _syncIconController;
 
   @override
   void initState() {
     super.initState();
+    _syncIconController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 1),
+    );
     _load();
   }
+
+  @override
+  void dispose() {
+    _syncIconController.dispose();
+    super.dispose();
+  }
+
+  int get _totalDirty => _dirtyCounts.values.fold(0, (a, b) => a + b);
 
   Future<void> _load() async {
     setState(() => _loading = true);
     try {
+      // Fire connectivity check without blocking — update UI when it resolves
+      widget.sdk.sync.isOnline().then((online) {
+        if (mounted) setState(() => _isOnline = online);
+      }).catchError((_) {
+        if (mounted) setState(() => _isOnline = false);
+      });
+
       final groups = await widget.sdk.meta.getMobileFormGroups();
       final counts = <String, int>{};
       final dirtyCounts = <String, int>{};
 
       for (final doctype in groups.values.expand((l) => l)) {
         try {
-          final docs = await widget.sdk.repository.getDocumentsByDoctype(doctype);
+          final docs =
+              await widget.sdk.repository.getDocumentsByDoctype(doctype);
           counts[doctype] = docs.length;
-          dirtyCounts[doctype] = docs.where((d) => d.status == 'dirty').length;
+          dirtyCounts[doctype] =
+              docs.where((d) => d.status == 'dirty').length;
         } catch (_) {
           counts[doctype] = 0;
           dirtyCounts[doctype] = 0;
@@ -63,6 +113,310 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
     }
   }
 
+  Future<void> _handleSync() async {
+    if (_isSyncing) return;
+    setState(() => _isSyncing = true);
+    _syncIconController.repeat();
+    try {
+      if (widget.onSyncPressed != null) {
+        await widget.onSyncPressed!();
+      } else {
+        try {
+          await widget.sdk.sync.pushSync();
+        } catch (_) {}
+        final doctypes = await widget.sdk.meta.getMobileFormDoctypeNames();
+        for (final dt in doctypes) {
+          try {
+            await widget.sdk.sync.pullSync(doctype: dt);
+          } catch (_) {}
+        }
+      }
+      await _load();
+    } finally {
+      if (mounted) {
+        _syncIconController.stop();
+        _syncIconController.reset();
+        setState(() => _isSyncing = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final userInfo = widget.sdk.currentUser;
+    final initials = _getInitials(userInfo?.fullName ?? userInfo?.email ?? '?');
+
+    return Scaffold(
+      appBar: AppBar(
+        titleSpacing: 12,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(widget.appTitle),
+            const SizedBox(width: 8),
+            _ConnectivityBadge(isOnline: _isOnline),
+          ],
+        ),
+        actions: [
+          if (_totalDirty > 0)
+            Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Center(
+                child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFF3E0),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.arrow_upward,
+                          size: 12, color: Color(0xFFE65100)),
+                      const SizedBox(width: 2),
+                      Text(
+                        '$_totalDirty',
+                        style: const TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.w700,
+                          color: Color(0xFFE65100),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          IconButton(
+            icon: RotationTransition(
+              turns: _syncIconController,
+              child: const Icon(Icons.sync),
+            ),
+            tooltip: 'Sync now',
+            onPressed: _isSyncing ? null : _handleSync,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: GestureDetector(
+              onTap: () => _showProfileSheet(context),
+              child: CircleAvatar(
+                radius: 16,
+                backgroundColor: cs.primaryContainer,
+                child: Text(
+                  initials,
+                  style: TextStyle(
+                    fontSize: 12,
+                    fontWeight: FontWeight.w700,
+                    color: cs.onPrimaryContainer,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: _load,
+        child: _loading
+            ? const Center(child: CircularProgressIndicator())
+            : _groups.isEmpty
+                ? _buildEmptyState()
+                : _buildGroupedList(),
+      ),
+    );
+  }
+
+  String _getInitials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length >= 2) {
+      return '${parts.first[0]}${parts.last[0]}'.toUpperCase();
+    }
+    return name.isNotEmpty ? name[0].toUpperCase() : '?';
+  }
+
+  Widget _buildEmptyState() {
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      children: const [
+        SizedBox(height: 120),
+        Center(
+          child: Text(
+            'No forms configured.\nPull down to refresh.',
+            textAlign: TextAlign.center,
+            style: TextStyle(color: Color(0xFF9E9E9E), fontSize: 14),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildGroupedList() {
+    return ListView.builder(
+      padding: const EdgeInsets.all(12),
+      itemCount: _groups.length,
+      itemBuilder: (context, index) {
+        final entry = _groups.entries.elementAt(index);
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: _GroupCard(
+            groupName: entry.key,
+            doctypes: entry.value,
+            counts: _counts,
+            dirtyCounts: _dirtyCounts,
+            onDoctypeTap: _navigateToDoctype,
+            groupHeaderBuilder: widget.groupHeaderBuilder,
+            tileBuilder: widget.tileBuilder,
+          ),
+        );
+      },
+    );
+  }
+
+  void _showProfileSheet(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final userInfo = widget.sdk.currentUser;
+    final fullName = userInfo?.fullName ?? 'User';
+    final email = userInfo?.email ?? '';
+    final initials = _getInitials(fullName);
+
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 36,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: cs.outline.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 20),
+                child: Row(
+                  children: [
+                    CircleAvatar(
+                      radius: 22,
+                      backgroundColor: cs.primaryContainer,
+                      child: Text(
+                        initials,
+                        style: TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w700,
+                          color: cs.onPrimaryContainer,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            fullName,
+                            style: TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                              color: cs.onSurface,
+                            ),
+                          ),
+                          if (email.isNotEmpty)
+                            Text(
+                              email,
+                              style: TextStyle(
+                                fontSize: 12,
+                                color: cs.onSurface.withValues(alpha: 0.6),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 12),
+              const Divider(height: 1),
+              ListTile(
+                leading: const Icon(Icons.logout, color: Color(0xFFD32F2F)),
+                title: const Text(
+                  'Logout',
+                  style: TextStyle(
+                    color: Color(0xFFD32F2F),
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+                onTap: () {
+                  Navigator.pop(sheetContext);
+                  _handleLogout();
+                },
+              ),
+              const SizedBox(height: 8),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _handleLogout() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Logout'),
+        content: const Text('Are you sure you want to logout?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Logout',
+                style: TextStyle(color: Color(0xFFD32F2F))),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !mounted) return;
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const Center(child: CircularProgressIndicator()),
+    );
+
+    try {
+      await widget.sdk.logout();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Logout warning: ${e.toString().split(':').last.trim()}'),
+            backgroundColor: const Color(0xFFE65100),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        Navigator.of(context).pop(); // dismiss loading
+      }
+      if (widget.onLogout != null) {
+        await widget.onLogout!();
+      }
+    }
+  }
+
   Future<void> _navigateToDoctype(String doctype) async {
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
@@ -70,7 +424,8 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
     );
     try {
       final meta = await widget.sdk.meta.getMeta(doctype);
-      final docs = await widget.sdk.repository.getDocumentsByDoctype(doctype);
+      final docs =
+          await widget.sdk.repository.getDocumentsByDoctype(doctype);
       try {
         await widget.sdk.sync.pullSync(doctype: doctype);
       } catch (_) {}
@@ -108,148 +463,301 @@ class _MobileHomeScreenState extends State<MobileHomeScreen> {
       }
     }
   }
+} // End of _MobileHomeScreenState
 
-  Future<void> _handleLogout() async {
-    if (widget.onLogout != null) {
-      await widget.onLogout!();
-    } else {
-      await widget.sdk.logout();
-    }
-  }
+class _GroupCard extends StatefulWidget {
+  final String groupName;
+  final List<String> doctypes;
+  final Map<String, int> counts;
+  final Map<String, int> dirtyCounts;
+  final void Function(String doctype) onDoctypeTap;
+  final Widget Function(BuildContext, String, int)? groupHeaderBuilder;
+  final Widget Function(BuildContext, String, int, int)? tileBuilder;
+
+  const _GroupCard({
+    required this.groupName,
+    required this.doctypes,
+    required this.counts,
+    required this.dirtyCounts,
+    required this.onDoctypeTap,
+    this.groupHeaderBuilder,
+    this.tileBuilder,
+  });
+
+  @override
+  State<_GroupCard> createState() => _GroupCardState();
+}
+
+class _GroupCardState extends State<_GroupCard> {
+  bool _expanded = true;
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.appTitle),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.logout),
-            tooltip: 'Logout',
-            onPressed: _handleLogout,
-          ),
-        ],
-      ),
-      body: RefreshIndicator(
-        onRefresh: _load,
-        child: _loading
-            ? const Center(child: Text('Loading...'))
-            : _groups.isEmpty
-                ? _buildEmptyState()
-                : _buildGroupedList(),
-      ),
-    );
-  }
+    final cs = Theme.of(context).colorScheme;
+    final formsCount = widget.doctypes.length;
 
-  Widget _buildEmptyState() {
-    return SingleChildScrollView(
-      physics: const AlwaysScrollableScrollPhysics(),
-      child: SizedBox(
-        height: 300,
-        child: const Center(
-          child: Text(
-            'No forms configured.\nPull down to refresh.',
-            textAlign: TextAlign.center,
-            style: TextStyle(color: Colors.grey),
-          ),
+    return Material(
+      color: cs.surface,
+      borderRadius: BorderRadius.circular(10),
+      clipBehavior: Clip.antiAlias,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border.all(color: cs.outline.withValues(alpha: 0.3)),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Column(
+          children: [
+            InkWell(
+              onTap: () => setState(() => _expanded = !_expanded),
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 14, vertical: 11),
+                decoration: BoxDecoration(
+                  color: cs.primaryContainer,
+                  border: _expanded
+                      ? Border(
+                          bottom: BorderSide(
+                              color: cs.outline.withValues(alpha: 0.2)))
+                      : null,
+                ),
+                child: widget.groupHeaderBuilder != null
+                    ? Row(
+                        children: [
+                          Expanded(
+                            child: widget.groupHeaderBuilder!(
+                                context, widget.groupName, formsCount),
+                          ),
+                          _chevron(cs),
+                        ],
+                      )
+                    : Row(
+                        children: [
+                          Expanded(
+                            child: Row(
+                              children: [
+                                Text(
+                                  widget.groupName,
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 13,
+                                    color: cs.onPrimaryContainer,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                      horizontal: 7, vertical: 1),
+                                  decoration: BoxDecoration(
+                                    color: cs.primary,
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                  child: Text(
+                                    '$formsCount',
+                                    style: const TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          _chevron(cs),
+                        ],
+                      ),
+              ),
+            ),
+            AnimatedSize(
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeInOut,
+              child: _expanded
+                  ? Column(
+                      children: [
+                        for (int i = 0; i < widget.doctypes.length; i++) ...[
+                          if (i > 0)
+                            Divider(
+                              height: 1,
+                              thickness: 1,
+                              color: cs.outline.withValues(alpha: 0.12),
+                            ),
+                          widget.tileBuilder != null
+                              ? widget.tileBuilder!(
+                                  context,
+                                  widget.doctypes[i],
+                                  widget.counts[widget.doctypes[i]] ?? 0,
+                                  widget.dirtyCounts[widget.doctypes[i]] ?? 0,
+                                )
+                              : _DoctypeTile(
+                                  doctype: widget.doctypes[i],
+                                  count:
+                                      widget.counts[widget.doctypes[i]] ?? 0,
+                                  dirtyCount: widget
+                                          .dirtyCounts[widget.doctypes[i]] ??
+                                      0,
+                                  onTap: () => widget
+                                      .onDoctypeTap(widget.doctypes[i]),
+                                ),
+                        ],
+                      ],
+                    )
+                  : const SizedBox.shrink(),
+            ),
+          ],
         ),
       ),
     );
   }
 
-  Widget _buildGroupedList() {
-    return ListView(
-      children: _groups.entries.map((entry) {
-        final groupName = entry.key;
-        final doctypes = entry.value;
-        final formsCount = doctypes.length;
-
-        return ExpansionTile(
-          initiallyExpanded: true,
-          backgroundColor: const Color(0xFFB2DFDB),
-          collapsedBackgroundColor: const Color(0xFFB2DFDB),
-          shape: const Border(left: BorderSide(color: Color(0xFF00796B), width: 4)),
-          collapsedShape: const Border(left: BorderSide(color: Color(0xFF00796B), width: 4)),
-          title: Row(
-            children: [
-              Text(
-                groupName,
-                style: const TextStyle(
-                  fontWeight: FontWeight.w800,
-                  color: Color(0xFF004D40),
-                  fontSize: 13,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 2),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF00796B),
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                child: Text(
-                  '$formsCount ${formsCount == 1 ? 'form' : 'forms'}',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 9,
-                    fontWeight: FontWeight.w700,
-                    letterSpacing: 0.3,
-                  ),
-                ),
-              ),
-            ],
-          ),
-          children: doctypes.map((doctype) => _buildDoctypeTile(doctype)).toList(),
-        );
-      }).toList(),
+  Widget _chevron(ColorScheme cs) {
+    return AnimatedRotation(
+      turns: _expanded ? 0.0 : -0.25,
+      duration: const Duration(milliseconds: 200),
+      child: Icon(
+        Icons.expand_more,
+        size: 20,
+        color: cs.onPrimaryContainer.withValues(alpha: 0.6),
+      ),
     );
   }
+}
 
-  Widget _buildDoctypeTile(String doctype) {
-    final count = _counts[doctype] ?? 0;
-    final dirty = _dirtyCounts[doctype] ?? 0;
+class _DoctypeTile extends StatelessWidget {
+  final String doctype;
+  final int count;
+  final int dirtyCount;
+  final VoidCallback onTap;
+
+  const _DoctypeTile({
+    required this.doctype,
+    required this.count,
+    required this.dirtyCount,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
 
     final String subtitle;
     final Color subtitleColor;
-    if (dirty > 0) {
-      subtitle = '↑ $dirty unsynced';
+    if (dirtyCount > 0) {
+      subtitle = '\u2191 $dirtyCount unsynced';
       subtitleColor = const Color(0xFFE65100);
     } else if (count > 0) {
-      subtitle = '✓ all synced';
+      subtitle = '\u2713 all synced';
       subtitleColor = const Color(0xFF388E3C);
     } else {
       subtitle = 'No records yet';
-      subtitleColor = Colors.grey;
+      subtitleColor = const Color(0xFF9E9E9E);
     }
 
-    final chipColor = count > 0 ? const Color(0xFFE0F2F1) : const Color(0xFFF5F5F5);
-    final chipTextColor = count > 0 ? const Color(0xFF00796B) : Colors.grey;
+    final bool hasUnsynced = dirtyCount > 0;
+    final chipColor = hasUnsynced
+        ? const Color(0xFFFFF3E0)
+        : cs.surfaceContainerHighest;
+    final chipTextColor = hasUnsynced
+        ? const Color(0xFFE65100)
+        : count > 0
+            ? cs.onSurface
+            : cs.onSurface.withValues(alpha: 0.4);
 
-    return ListTile(
-      title: Text(
-        doctype,
-        style: const TextStyle(
-          fontSize: 12,
-          fontWeight: FontWeight.w600,
-          color: Color(0xFF212121),
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    doctype,
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: cs.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: subtitleColor,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 10, vertical: 3),
+              decoration: BoxDecoration(
+                color: chipColor,
+                borderRadius: BorderRadius.circular(14),
+              ),
+              child: Text(
+                '$count',
+                style: TextStyle(
+                  fontSize: 12,
+                  fontWeight: FontWeight.w700,
+                  color: chipTextColor,
+                ),
+              ),
+            ),
+            const SizedBox(width: 6),
+            Icon(
+              Icons.chevron_right,
+              size: 18,
+              color: cs.outline.withValues(alpha: 0.4),
+            ),
+          ],
         ),
       ),
-      subtitle: Text(
-        subtitle,
-        style: TextStyle(fontSize: 10, color: subtitleColor, fontWeight: FontWeight.w500),
+    );
+  }
+}
+
+class _ConnectivityBadge extends StatelessWidget {
+  final bool isOnline;
+
+  const _ConnectivityBadge({required this.isOnline});
+
+  @override
+  Widget build(BuildContext context) {
+    final color = isOnline ? const Color(0xFF388E3C) : const Color(0xFFD32F2F);
+    final bgColor =
+        isOnline ? const Color(0xFFE8F5E9) : const Color(0xFFFFEBEE);
+    final label = isOnline ? 'Online' : 'Offline';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: bgColor,
+        borderRadius: BorderRadius.circular(10),
       ),
-      trailing: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 9, vertical: 3),
-        decoration: BoxDecoration(
-          color: chipColor,
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Text(
-          '$count',
-          style: TextStyle(fontSize: 11, fontWeight: FontWeight.w700, color: chipTextColor),
-        ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+          ),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 10,
+              fontWeight: FontWeight.w500,
+              color: color,
+            ),
+          ),
+        ],
       ),
-      onTap: () => _navigateToDoctype(doctype),
     );
   }
 }

--- a/lib/src/sdk/frappe_sdk.dart
+++ b/lib/src/sdk/frappe_sdk.dart
@@ -173,7 +173,9 @@ class FrappeSDK {
 
   /// Logout and clear all local DB data (default). Set clearDatabase: false to keep DB.
   Future<void> logout({bool clearDatabase = true}) async {
-    if (!_initialized) return;
+    if (!_initialized) {
+      throw StateError('Cannot logout: SDK not initialized. Call initialize() first.');
+    }
     await _authService!.logout(clearDatabase: clearDatabase);
   }
 
@@ -261,6 +263,10 @@ class FrappeSDK {
 
   /// Roles for the currently authenticated user (if provided by backend).
   List<String> get roles => _authService?.roles ?? const [];
+
+  /// Returns the current authenticated user's info, or null.
+  ({String email, String fullName})? get currentUser =>
+      _authService?.currentUserInfo;
 
   /// Stable UUID for this device/install. Use when creating docs from mobile so server can set mobile_uuid.
   Future<String> getMobileUuid() async {

--- a/lib/src/sdk/frappe_sdk.dart
+++ b/lib/src/sdk/frappe_sdk.dart
@@ -1,6 +1,8 @@
 // Copyright (c) 2026, Bhushan Barbuddhe and contributors
 // For license information, please see license.txt
 
+import 'package:flutter/foundation.dart';
+
 import '../api/client.dart';
 import '../database/app_database.dart';
 import '../services/auth_service.dart';
@@ -28,6 +30,32 @@ class FrappeSDK {
   bool _initialized = false;
 
   FrappeSDK({required this.baseUrl});
+
+  /// Test-only constructor: accepts a pre-built [AppDatabase] (e.g. in-memory).
+  /// Wires all services directly without calling [initialize()].
+  /// Avoids FlutterSecureStorage (not available in unit/widget tests).
+  @visibleForTesting
+  FrappeSDK.forTesting(String baseUrl, AppDatabase database)
+      : baseUrl = baseUrl {
+    _database = database;
+    // Create FrappeClient directly — avoids AuthService.initialize() which
+    // writes to FlutterSecureStorage and hangs in widget tests.
+    _client = FrappeClient(baseUrl);
+    // AuthService is set to a stub instance (not initialized) so getters work.
+    _authService = AuthService();
+    _repository = OfflineRepository(_database!);
+    _metaService = MetaService(_client!, _database!);
+    _permissionService = PermissionService(_client!, _database!);
+    _translationService = TranslationService(_client!);
+    _syncService = SyncService(
+      _client!,
+      _repository!,
+      _database!,
+      getMobileUuid: () async => 'test-uuid',
+    );
+    _linkOptionService = LinkOptionService(_client!);
+    _initialized = true;
+  }
 
   /// Initialize SDK (call this first).
   ///

--- a/lib/src/sdk/frappe_sdk.dart
+++ b/lib/src/sdk/frappe_sdk.dart
@@ -39,10 +39,13 @@ class FrappeSDK {
       : baseUrl = baseUrl {
     _database = database;
     // Create FrappeClient directly — avoids AuthService.initialize() which
-    // writes to FlutterSecureStorage and hangs in widget tests.
+    // writes to FlutterSecureStorage and is unavailable in widget tests.
     _client = FrappeClient(baseUrl);
-    // AuthService is set to a stub instance (not initialized) so getters work.
-    _authService = AuthService();
+    // Use AuthService.forTesting so the client and database are wired up
+    // without touching FlutterSecureStorage. This means sdk.auth methods
+    // (e.g. getOrCreateMobileUuid, restoreSession) won't throw "not
+    // initialized" if called from any production code path under test.
+    _authService = AuthService.forTesting(_client!, database: database);
     _repository = OfflineRepository(_database!);
     _metaService = MetaService(_client!, _database!);
     _permissionService = PermissionService(_client!, _database!);

--- a/lib/src/services/auth_service.dart
+++ b/lib/src/services/auth_service.dart
@@ -33,6 +33,12 @@ class AuthService {
   List<String> _roles = [];
   String? _language;
 
+  /// Cached user info from the last successful authentication.
+  ({String email, String fullName})? _cachedUserInfo;
+
+  /// Returns the current user's email and full name, or null if not authenticated.
+  ({String email, String fullName})? get currentUserInfo => _cachedUserInfo;
+
   /// Default constructor. Call [initialize] before using auth methods.
   AuthService();
 
@@ -355,6 +361,7 @@ class AuthService {
 
     _client!.rest.setBearerToken(accessToken);
     _isAuthenticated = true;
+    _cachedUserInfo = (email: user, fullName: fullName ?? user);
   }
 
   /// Authenticates with API key and secret.
@@ -395,6 +402,7 @@ class AuthService {
         if (token != null && token.accessToken.isNotEmpty) {
           _client!.rest.setBearerToken(token.accessToken);
           _isAuthenticated = true;
+          _cachedUserInfo = (email: token.user, fullName: token.fullName ?? token.user);
           return true;
         }
       } catch (_) {
@@ -542,6 +550,7 @@ class AuthService {
     } catch (_) {}
     _client?.rest.setBearerToken(null);
     _isAuthenticated = false;
+    _cachedUserInfo = null;
     _roles = [];
     await _storage.delete(key: _keyApiKey);
     await _storage.delete(key: _keyApiSecret);

--- a/lib/src/services/auth_service.dart
+++ b/lib/src/services/auth_service.dart
@@ -33,6 +33,17 @@ class AuthService {
   List<String> _roles = [];
   String? _language;
 
+  /// Default constructor. Call [initialize] before using auth methods.
+  AuthService();
+
+  /// Named constructor used by [FrappeSDK.forTesting]: wires [client] and
+  /// [database] directly without touching [FlutterSecureStorage] (which is
+  /// unavailable in unit/widget tests).
+  AuthService.forTesting(FrappeClient client, {AppDatabase? database}) {
+    _client = client;
+    _database = database;
+  }
+
   /// Initializes the client with the given [baseUrl].
   ///
   /// Optionally provide [database] for stateless login token storage.

--- a/lib/src/services/link_option_service.dart
+++ b/lib/src/services/link_option_service.dart
@@ -1,10 +1,11 @@
 import 'dart:convert';
+
 import '../api/client.dart';
 import '../database/app_database.dart';
 import '../database/entities/link_option_entity.dart';
 import '../models/doc_type_meta.dart';
-import 'meta_service.dart';
 import '../utils/depends_on_evaluator.dart';
+import 'meta_service.dart';
 
 const int _kLinkOptionCacheMaxEntries = 30;
 
@@ -25,8 +26,7 @@ class LinkOptionService {
   }
 
   void _putCache(String key, List<LinkOptionEntity> options) {
-    if (_memoryCache.length >= _kLinkOptionCacheMaxEntries &&
-        !_memoryCache.containsKey(key)) {
+    if (_memoryCache.length >= _kLinkOptionCacheMaxEntries && !_memoryCache.containsKey(key)) {
       if (_cacheKeys.isNotEmpty) {
         final evict = _cacheKeys.removeAt(0);
         _memoryCache.remove(evict);
@@ -48,19 +48,32 @@ class LinkOptionService {
       return _memoryCache[key]!;
     }
 
-    final titleField = await _getTitleField(doctype);
+    final meta = await _getDocTypeMeta(doctype);
+    final titleField = _resolveTitleField(doctype, meta);
 
     List<dynamic> documents;
+
     try {
-      documents = await _client.doctype.list(
-        doctype,
-        fields: ['*'],
-        filters: normalizedFilters,
-        limitPageLength: 1000,
-      );
+      // For child doctypes (istable=1), get_list/reportview only return
+      // standard fields. Batch-fetch full docs via /api/resource instead.
+      if (meta != null && meta.isTable) {
+        documents = await _client.doctype.listChildDocs(
+          doctype,
+          filters: normalizedFilters,
+          limitPageLength: 5000,
+        );
+      } else {
+        documents = await _client.doctype.list(
+          doctype,
+          fields: ['*'],
+          filters: normalizedFilters,
+          limitPageLength: 5000,
+        );
+      }
     } catch (_) {
       return [];
     }
+
     final now = DateTime.now().millisecondsSinceEpoch;
     final linkOptions = <LinkOptionEntity>[];
 
@@ -79,13 +92,7 @@ class LinkOptionService {
         label = docMap[titleField].toString();
       }
       // Fall back to common label fields if title field is not available or empty
-      for (final k in [
-        'title',
-        'full_name',
-        'customer_name',
-        'supplier_name',
-        'label',
-      ]) {
+      for (final k in ['title', 'full_name', 'customer_name', 'supplier_name', 'label']) {
         if (label != null && label.isNotEmpty) break;
         if (docMap.containsKey(k) && docMap[k] != null) {
           label = docMap[k].toString();
@@ -141,9 +148,7 @@ class LinkOptionService {
     if (linkFiltersJson == null || linkFiltersJson.isEmpty) return [];
     try {
       final decoded = jsonDecode(linkFiltersJson) as dynamic;
-      final filters = decoded is List
-          ? List<dynamic>.from(decoded)
-          : <dynamic>[];
+      final filters = decoded is List ? List<dynamic>.from(decoded) : <dynamic>[];
       final names = <String>[];
       for (final filter in filters) {
         if (filter is! List || filter.length < 4) continue;
@@ -172,9 +177,7 @@ class LinkOptionService {
     if (linkFiltersJson == null || linkFiltersJson.isEmpty) return null;
     try {
       final decoded = jsonDecode(linkFiltersJson) as dynamic;
-      final filters = decoded is List
-          ? List<dynamic>.from(decoded)
-          : <dynamic>[];
+      final filters = decoded is List ? List<dynamic>.from(decoded) : <dynamic>[];
       final result = <List<dynamic>>[];
       for (final filter in filters) {
         if (filter is! List || filter.length < 4) continue;
@@ -204,13 +207,13 @@ class LinkOptionService {
     _titleFieldCache.remove(doctype);
   }
 
-  //get title field from docType db. API if online.
-  Future<String?> _getTitleField(String doctype) async {
+  /// Resolves the display field for a doctype.
+  /// Checks title_field first, then falls back to first search_field from meta
+  /// (common for child doctypes where title_field is not set).
+  String? _resolveTitleField(String doctype, DocTypeMeta? meta) {
     if (_titleFieldCache.containsKey(doctype)) {
       return _titleFieldCache[doctype];
     }
-
-    final meta = await _getDocTypeMeta(doctype);
     final titleField = meta?.titleField;
     _titleFieldCache[doctype] = titleField;
     return titleField;

--- a/lib/src/services/meta_service.dart
+++ b/lib/src/services/meta_service.dart
@@ -292,8 +292,7 @@ class MetaService {
   ///
   /// Marks all existing mobile forms as false, then updates/creates entries
   /// for the provided mobile form names. Returns list of doctypes that need syncing.
-  @visibleForTesting
-  Future<List<String>> updateMobileFormDoctypesForTest(
+  Future<List<String>> _updateMobileFormDoctypes(
     List<MobileFormName> mobileFormNames,
   ) async {
     // First, mark all existing mobile forms as false (loop 1)
@@ -371,6 +370,12 @@ class MetaService {
     return doctypesToSync;
   }
 
+  /// Thin wrapper for testing purposes only.
+  @visibleForTesting
+  Future<List<String>> updateMobileFormDoctypesForTest(
+    List<MobileFormName> mobileFormNames,
+  ) => _updateMobileFormDoctypes(mobileFormNames);
+
   /// Fetches mobile configuration from server and resyncs doctype metadata.
   ///
   /// Calls `/api/v2/method/mobile_auth.configuration` to get updated mobile form list
@@ -407,7 +412,7 @@ class MetaService {
       }
 
       // Update mobile form doctypes and get list of doctypes to sync
-      final doctypesToSync = await updateMobileFormDoctypesForTest(mobileFormNames);
+      final doctypesToSync = await _updateMobileFormDoctypes(mobileFormNames);
 
       // Sync all doctypes that need updating
       if (doctypesToSync.isNotEmpty) {

--- a/lib/src/services/meta_service.dart
+++ b/lib/src/services/meta_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import '../api/client.dart';
 import '../models/doc_type_meta.dart';
 import '../models/mobile_form_name.dart';
@@ -43,6 +44,8 @@ class MetaService {
       serverModifiedAt: existing?.serverModifiedAt,
       isMobileForm: existing?.isMobileForm ?? false,
       metaJson: jsonEncode(metaData),
+      groupName: existing?.groupName,
+      sortOrder: existing?.sortOrder,
     );
     // Check if exists, update if present, insert if new
     if (existing != null) {
@@ -117,6 +120,8 @@ class MetaService {
       serverModifiedAt: existing?.serverModifiedAt,
       isMobileForm: existing?.isMobileForm ?? false,
       metaJson: jsonEncode(metaData),
+      groupName: existing?.groupName,
+      sortOrder: existing?.sortOrder,
     );
     if (existing != null) {
       await _database.doctypeMetaDao.updateDoctypeMeta(entity);
@@ -225,6 +230,21 @@ class MetaService {
     return list.map((e) => e.doctype).toList();
   }
 
+  /// Returns doctypes grouped by group name, ordered by server-defined sort order.
+  ///
+  /// Groups are ordered by the lowest sortOrder of any member.
+  /// Doctypes with null or empty groupName are placed in an 'Other' bucket.
+  /// Returns an empty map if no mobile forms are configured.
+  Future<Map<String, List<String>>> getMobileFormGroups() async {
+    final list = await _database.doctypeMetaDao.findMobileFormDoctypes();
+    final groups = <String, List<String>>{};
+    for (final entity in list) {
+      final group = (entity.groupName?.isNotEmpty == true) ? entity.groupName! : 'Other';
+      groups.putIfAbsent(group, () => []).add(entity.doctype);
+    }
+    return groups;
+  }
+
   /// Prefetch metadata for all mobile form doctypes into DB.
   Future<void> prefetchMobileFormDoctypes() async {
     try {
@@ -272,10 +292,11 @@ class MetaService {
   ///
   /// Marks all existing mobile forms as false, then updates/creates entries
   /// for the provided mobile form names. Returns list of doctypes that need syncing.
-  Future<List<String>> _updateMobileFormDoctypes(
+  @visibleForTesting
+  Future<List<String>> updateMobileFormDoctypesForTest(
     List<MobileFormName> mobileFormNames,
   ) async {
-    // First, mark all existing mobile forms as false
+    // First, mark all existing mobile forms as false (loop 1)
     final allMetas = await _database.doctypeMetaDao.findAll();
     for (final meta in allMetas) {
       if (meta.isMobileForm) {
@@ -285,15 +306,18 @@ class MetaService {
           serverModifiedAt: meta.serverModifiedAt,
           isMobileForm: false,
           metaJson: meta.metaJson,
+          groupName: meta.groupName,
+          sortOrder: meta.sortOrder,
         );
         await _database.doctypeMetaDao.updateDoctypeMeta(updatedMeta);
       }
     }
 
-    // Now update/create entries for mobile forms
+    // Now update/create entries for mobile forms (loop 2)
     final doctypesToSync = <String>[];
 
-    for (final mfn in mobileFormNames) {
+    for (int i = 0; i < mobileFormNames.length; i++) {
+      final mfn = mobileFormNames[i];
       final doctype = mfn.mobileDoctype;
       final existing = await _database.doctypeMetaDao.findByDoctype(doctype);
 
@@ -317,6 +341,8 @@ class MetaService {
           serverModifiedAt: mfn.doctypeMetaModifiedAt,
           isMobileForm: true,
           metaJson: existing.metaJson,
+          groupName: mfn.groupName,
+          sortOrder: i,
         );
         await _database.doctypeMetaDao.updateDoctypeMeta(updatedMeta);
 
@@ -334,6 +360,8 @@ class MetaService {
           serverModifiedAt: mfn.doctypeMetaModifiedAt,
           isMobileForm: true,
           metaJson: '{}', // Empty until metadata is fetched
+          groupName: mfn.groupName,
+          sortOrder: i,
         );
         await _database.doctypeMetaDao.insertDoctypeMeta(newMeta);
         doctypesToSync.add(doctype);
@@ -379,7 +407,7 @@ class MetaService {
       }
 
       // Update mobile form doctypes and get list of doctypes to sync
-      final doctypesToSync = await _updateMobileFormDoctypes(mobileFormNames);
+      final doctypesToSync = await updateMobileFormDoctypesForTest(mobileFormNames);
 
       // Sync all doctypes that need updating
       if (doctypesToSync.isNotEmpty) {

--- a/lib/src/ui/widgets/fields/child_table_field.dart
+++ b/lib/src/ui/widgets/fields/child_table_field.dart
@@ -83,8 +83,7 @@ class ChildTableField extends StatelessWidget {
                 child: ListTile(
                   title: FutureBuilder<String>(
                     future: _rowTitle(row),
-                    builder: (_, snap) =>
-                        Text(snap.data ?? '…'),
+                    builder: (_, snap) => Text(snap.data ?? '…'),
                   ),
                   subtitle: _rowSubtitle(row).isNotEmpty
                       ? Text(_rowSubtitle(row))

--- a/lib/src/ui/widgets/form_builder.dart
+++ b/lib/src/ui/widgets/form_builder.dart
@@ -111,7 +111,8 @@ class FrappeFormBuilder extends StatefulWidget {
     String fieldName,
     dynamic newValue,
     Map<String, dynamic> formData,
-  )? onFieldChange;
+  )?
+  onFieldChange;
 
   const FrappeFormBuilder({
     super.key,
@@ -177,8 +178,7 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
     _formData.addAll(widget.initialData ?? {});
 
     for (final field in widget.meta.fields) {
-      if (field.fieldname != null &&
-          !_formData.containsKey(field.fieldname)) {
+      if (field.fieldname != null && !_formData.containsKey(field.fieldname)) {
         _formData[field.fieldname!] ??= field.defaultValue;
       }
     }
@@ -493,6 +493,24 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
       });
       _formKey.currentState?.patchValue(_normalizePatchValues(updates));
       if (mounted) setState(() {});
+
+      // Chain: if a patched field is itself a Link, trigger its dependents too.
+      // e.g. learner_name → household_survey (Link) → religion, category
+      for (final entry in updates.entries) {
+        if (entry.value == null || entry.value.toString().trim().isEmpty) {
+          continue;
+        }
+        DocField? updatedFieldMeta;
+        for (final f in widget.meta.fields) {
+          if (f.fieldname == entry.key) {
+            updatedFieldMeta = f;
+            break;
+          }
+        }
+        if (updatedFieldMeta?.fieldtype == FieldTypes.link) {
+          _handleFetchFrom(entry.key, entry.value.toString());
+        }
+      }
     } catch (e) {
       debugPrint('FetchFrom error: $e');
     }

--- a/test/frappe_sdk_test.dart
+++ b/test/frappe_sdk_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frappe_mobile_sdk/frappe_mobile_sdk.dart';
+import 'package:frappe_mobile_sdk/src/database/app_database.dart';
+import 'package:frappe_mobile_sdk/src/sdk/frappe_sdk.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  test('currentUser returns null when not authenticated', () async {
+    final db = await AppDatabase.inMemoryDatabase();
+    final sdk = FrappeSDK.forTesting('http://test', db);
+
+    expect(sdk.currentUser, isNull);
+  });
+
+  test('logout throws StateError when SDK not initialized', () async {
+    final sdk = FrappeSDK(baseUrl: 'http://test');
+
+    // logout() is async — use expectLater to catch the thrown StateError
+    await expectLater(sdk.logout(), throwsA(isA<StateError>()));
+  });
+}

--- a/test/meta_service_test.dart
+++ b/test/meta_service_test.dart
@@ -152,4 +152,57 @@ void main() {
       await databaseFactoryFfi.deleteDatabase(dbPath);
     });
   });
+
+  group('DoctypeMetaDao.findMobileFormDoctypes ordering', () {
+    test('returns mobile form doctypes sorted by sortOrder ASC', () async {
+      const dbPath = 'ordering_test.db';
+      await databaseFactoryFfi.deleteDatabase(dbPath);
+      final rawDb = await databaseFactoryFfi.openDatabase(
+        dbPath,
+        options: OpenDatabaseOptions(
+          version: 2,
+          singleInstance: false,
+          onCreate: (db, v) async {
+            await db.execute('''
+              CREATE TABLE doctype_meta (
+                doctype TEXT PRIMARY KEY,
+                modified TEXT,
+                serverModifiedAt TEXT,
+                isMobileForm INTEGER NOT NULL DEFAULT 0,
+                metaJson TEXT NOT NULL,
+                groupName TEXT,
+                sortOrder INTEGER
+              )
+            ''');
+          },
+        ),
+      );
+
+      // Insert in reverse sortOrder to confirm ordering is explicit, not insertion-based
+      await rawDb.insert('doctype_meta', {
+        'doctype': 'FormC', 'modified': null, 'serverModifiedAt': null,
+        'isMobileForm': 1, 'metaJson': '{}', 'groupName': 'G1', 'sortOrder': 2,
+      });
+      await rawDb.insert('doctype_meta', {
+        'doctype': 'FormA', 'modified': null, 'serverModifiedAt': null,
+        'isMobileForm': 1, 'metaJson': '{}', 'groupName': 'G1', 'sortOrder': 0,
+      });
+      await rawDb.insert('doctype_meta', {
+        'doctype': 'FormB', 'modified': null, 'serverModifiedAt': null,
+        'isMobileForm': 1, 'metaJson': '{}', 'groupName': 'G2', 'sortOrder': 1,
+      });
+
+      final maps = await rawDb.query(
+        'doctype_meta',
+        where: 'isMobileForm = ?',
+        whereArgs: [1],
+        orderBy: 'sortOrder ASC',
+      );
+      final doctypes = maps.map((m) => m['doctype'] as String).toList();
+      expect(doctypes, ['FormA', 'FormB', 'FormC']);
+
+      await rawDb.close();
+      await databaseFactoryFfi.deleteDatabase(dbPath);
+    });
+  });
 }

--- a/test/meta_service_test.dart
+++ b/test/meta_service_test.dart
@@ -301,8 +301,8 @@ void main() {
     });
   });
 
-  group('MetaService preserves groupName on meta refresh', () {
-    test('fetchAndStoreInDb preserves groupName of existing row', () async {
+  group('DoctypeMetaDao preserves groupName on update', () {
+    test('updateDoctypeMeta preserves groupName and sortOrder from existing row', () async {
       final db = await AppDatabase.inMemoryDatabase();
 
       await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(

--- a/test/meta_service_test.dart
+++ b/test/meta_service_test.dart
@@ -5,6 +5,7 @@ import 'package:frappe_mobile_sdk/src/api/client.dart';
 import 'package:frappe_mobile_sdk/src/database/app_database.dart';
 import 'package:frappe_mobile_sdk/src/database/daos/doctype_meta_dao.dart';
 import 'package:frappe_mobile_sdk/src/database/entities/doctype_meta_entity.dart';
+import 'package:frappe_mobile_sdk/src/models/mobile_form_name.dart';
 import 'package:frappe_mobile_sdk/src/services/meta_service.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
@@ -200,6 +201,132 @@ void main() {
 
       await rawDb.close();
       await databaseFactoryFfi.deleteDatabase(dbPath);
+    });
+  });
+
+  group('_updateMobileFormDoctypes loop behaviour', () {
+    test('loop 2 writes groupName and sortOrder from MobileFormName list', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      final client = FrappeClient('https://fake.test');
+      final metaService = MetaService(client, db);
+
+      final forms = [
+        MobileFormName(mobileDoctype: 'Form A', groupName: 'Group1', doctypeMetaModifiedAt: null, doctypeIcon: null),
+        MobileFormName(mobileDoctype: 'Form B', groupName: 'Group2', doctypeMetaModifiedAt: null, doctypeIcon: null),
+        MobileFormName(mobileDoctype: 'Form C', groupName: 'Group1', doctypeMetaModifiedAt: null, doctypeIcon: null),
+      ];
+
+      await metaService.updateMobileFormDoctypesForTest(forms);
+
+      final a = await db.doctypeMetaDao.findByDoctype('Form A');
+      final b = await db.doctypeMetaDao.findByDoctype('Form B');
+      final c = await db.doctypeMetaDao.findByDoctype('Form C');
+
+      expect(a?.groupName, 'Group1');
+      expect(a?.sortOrder, 0);
+      expect(b?.groupName, 'Group2');
+      expect(b?.sortOrder, 1);
+      expect(c?.groupName, 'Group1');
+      expect(c?.sortOrder, 2);
+    });
+
+    test('loop 1 preserves groupName and sortOrder when marking isMobileForm=false', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      final client = FrappeClient('https://fake.test');
+      final metaService = MetaService(client, db);
+
+      // First call: set up a row with groupName
+      await metaService.updateMobileFormDoctypesForTest([
+        MobileFormName(mobileDoctype: 'Survey', groupName: 'Survey Group', doctypeMetaModifiedAt: null, doctypeIcon: null),
+      ]);
+
+      // Second call with different set — loop 1 marks 'Survey' as isMobileForm=false
+      // It must NOT null out groupName/sortOrder during that step
+      await metaService.updateMobileFormDoctypesForTest([
+        MobileFormName(mobileDoctype: 'Assessment', groupName: 'Assessment Group', doctypeMetaModifiedAt: null, doctypeIcon: null),
+      ]);
+
+      final survey = await db.doctypeMetaDao.findByDoctype('Survey');
+      expect(survey?.groupName, 'Survey Group');
+      expect(survey?.sortOrder, 0);
+      expect(survey?.isMobileForm, isFalse);
+    });
+  });
+
+  group('MetaService.getMobileFormGroups', () {
+    test('returns groups in sortOrder order', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      final client = FrappeClient('https://fake.test');
+      final metaService = MetaService(client, db);
+
+      await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(
+        doctype: 'Z Form', modified: null, serverModifiedAt: null,
+        isMobileForm: true, metaJson: '{}', groupName: 'ZGroup', sortOrder: 2,
+      ));
+      await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(
+        doctype: 'A Form', modified: null, serverModifiedAt: null,
+        isMobileForm: true, metaJson: '{}', groupName: 'AGroup', sortOrder: 0,
+      ));
+      await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(
+        doctype: 'M Form', modified: null, serverModifiedAt: null,
+        isMobileForm: true, metaJson: '{}', groupName: 'MGroup', sortOrder: 1,
+      ));
+
+      final groups = await metaService.getMobileFormGroups();
+      expect(groups.keys.toList(), ['AGroup', 'MGroup', 'ZGroup']);
+    });
+
+    test('places null groupName into Other bucket', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      final client = FrappeClient('https://fake.test');
+      final metaService = MetaService(client, db);
+
+      await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(
+        doctype: 'Ungrouped Form', modified: null, serverModifiedAt: null,
+        isMobileForm: true, metaJson: '{}', sortOrder: 0,
+      ));
+
+      final groups = await metaService.getMobileFormGroups();
+      expect(groups.containsKey('Other'), isTrue);
+      expect(groups['Other'], contains('Ungrouped Form'));
+    });
+
+    test('returns empty map when no mobile forms exist', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      final client = FrappeClient('https://fake.test');
+      final metaService = MetaService(client, db);
+
+      final groups = await metaService.getMobileFormGroups();
+      expect(groups, isEmpty);
+    });
+  });
+
+  group('MetaService preserves groupName on meta refresh', () {
+    test('fetchAndStoreInDb preserves groupName of existing row', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+
+      await db.doctypeMetaDao.insertDoctypeMeta(DoctypeMetaEntity(
+        doctype: 'My Form', modified: '2026-01-01', serverModifiedAt: '2026-01-01',
+        isMobileForm: true, metaJson: '{"fields":[]}',
+        groupName: 'My Group', sortOrder: 5,
+      ));
+
+      final existing = await db.doctypeMetaDao.findByDoctype('My Form');
+      final refreshed = DoctypeMetaEntity(
+        doctype: 'My Form',
+        modified: '2026-01-02',
+        serverModifiedAt: existing?.serverModifiedAt,
+        isMobileForm: existing?.isMobileForm ?? false,
+        metaJson: '{"fields":[{"fieldname":"title"}]}',
+        groupName: existing?.groupName,
+        sortOrder: existing?.sortOrder,
+      );
+      await db.doctypeMetaDao.updateDoctypeMeta(refreshed);
+
+      final result = await db.doctypeMetaDao.findByDoctype('My Form');
+      expect(result?.groupName, 'My Group');
+      expect(result?.sortOrder, 5);
+      expect(result?.modified, '2026-01-02');
     });
   });
 }

--- a/test/meta_service_test.dart
+++ b/test/meta_service_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:frappe_mobile_sdk/src/api/client.dart';
 import 'package:frappe_mobile_sdk/src/database/app_database.dart';
+import 'package:frappe_mobile_sdk/src/database/daos/doctype_meta_dao.dart';
 import 'package:frappe_mobile_sdk/src/database/entities/doctype_meta_entity.dart';
 import 'package:frappe_mobile_sdk/src/services/meta_service.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
@@ -192,13 +193,9 @@ void main() {
         'isMobileForm': 1, 'metaJson': '{}', 'groupName': 'G2', 'sortOrder': 1,
       });
 
-      final maps = await rawDb.query(
-        'doctype_meta',
-        where: 'isMobileForm = ?',
-        whereArgs: [1],
-        orderBy: 'sortOrder ASC',
-      );
-      final doctypes = maps.map((m) => m['doctype'] as String).toList();
+      final dao = DoctypeMetaDao(rawDb);
+      final results = await dao.findMobileFormDoctypes();
+      final doctypes = results.map((e) => e.doctype).toList();
       expect(doctypes, ['FormA', 'FormB', 'FormC']);
 
       await rawDb.close();

--- a/test/meta_service_test.dart
+++ b/test/meta_service_test.dart
@@ -68,4 +68,88 @@ void main() {
       expect(names, isNot(contains('Lead')));
     });
   });
+
+  group('DB migration v1→v2', () {
+    test('groupName and sortOrder columns exist after onCreate', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      await db.doctypeMetaDao.insertDoctypeMeta(
+        DoctypeMetaEntity(
+          doctype: 'TestDoc',
+          modified: null,
+          serverModifiedAt: null,
+          isMobileForm: true,
+          metaJson: '{}',
+          groupName: 'TestGroup',
+          sortOrder: 0,
+        ),
+      );
+      final result = await db.doctypeMetaDao.findByDoctype('TestDoc');
+      expect(result?.groupName, 'TestGroup');
+      expect(result?.sortOrder, 0);
+    });
+
+    test('groupName defaults to null when not provided', () async {
+      final db = await AppDatabase.inMemoryDatabase();
+      await db.doctypeMetaDao.insertDoctypeMeta(
+        DoctypeMetaEntity(
+          doctype: 'NoGroup',
+          modified: null,
+          serverModifiedAt: null,
+          isMobileForm: false,
+          metaJson: '{}',
+        ),
+      );
+      final result = await db.doctypeMetaDao.findByDoctype('NoGroup');
+      expect(result?.groupName, isNull);
+      expect(result?.sortOrder, isNull);
+    });
+
+    test('onUpgrade adds groupName and sortOrder to existing v1 database', () async {
+      const dbPath = 'v1_migration_test.db';
+      // Delete any leftover DB from a previous run to ensure a clean slate
+      await databaseFactoryFfi.deleteDatabase(dbPath);
+
+      final rawDb = await databaseFactoryFfi.openDatabase(
+        dbPath,
+        options: OpenDatabaseOptions(
+          version: 1,
+          singleInstance: false,
+          onCreate: (db, v) async {
+            await db.execute('''
+              CREATE TABLE doctype_meta (
+                doctype TEXT PRIMARY KEY,
+                modified TEXT,
+                serverModifiedAt TEXT,
+                isMobileForm INTEGER NOT NULL DEFAULT 0,
+                metaJson TEXT NOT NULL
+              )
+            ''');
+          },
+        ),
+      );
+      await rawDb.insert('doctype_meta', {
+        'doctype': 'OldDoc',
+        'modified': '2025-01-01',
+        'serverModifiedAt': null,
+        'isMobileForm': 1,
+        'metaJson': '{}',
+      });
+      // Simulate onUpgrade 1→2
+      await rawDb.execute('ALTER TABLE doctype_meta ADD COLUMN groupName TEXT');
+      await rawDb.execute('ALTER TABLE doctype_meta ADD COLUMN sortOrder INTEGER');
+      final rows = await rawDb.query('doctype_meta', where: 'doctype = ?', whereArgs: ['OldDoc']);
+      expect(rows.length, 1);
+      expect(rows.first['groupName'], isNull);
+      expect(rows.first['sortOrder'], isNull);
+      await rawDb.insert('doctype_meta', {
+        'doctype': 'NewDoc', 'modified': null, 'serverModifiedAt': null,
+        'isMobileForm': 1, 'metaJson': '{}', 'groupName': 'MyGroup', 'sortOrder': 0,
+      });
+      final newRows = await rawDb.query('doctype_meta', where: 'doctype = ?', whereArgs: ['NewDoc']);
+      expect(newRows.first['groupName'], 'MyGroup');
+      await rawDb.close();
+      // Clean up
+      await databaseFactoryFfi.deleteDatabase(dbPath);
+    });
+  });
 }

--- a/test/mobile_home_screen_test.dart
+++ b/test/mobile_home_screen_test.dart
@@ -80,4 +80,41 @@ void main() {
     await tester.pump();
     expect(find.text('My App'), findsOneWidget);
   });
+
+  testWidgets('renders group as card with chevron', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: sdkWithSurvey, appTitle: 'TestApp'),
+    ));
+    await tester.runAsync(() async {
+      final groups = await sdkWithSurvey.meta.getMobileFormGroups();
+      for (final doctype in groups.values.expand((l) => l)) {
+        await sdkWithSurvey.repository.getDocumentsByDoctype(doctype);
+      }
+    });
+    await tester.pump();
+
+    expect(find.text('Survey'), findsOneWidget);
+    expect(find.text('Survey Form'), findsOneWidget);
+    // Chevron icon for navigation hint on each tile
+    expect(find.byIcon(Icons.chevron_right), findsOneWidget);
+  });
+
+  testWidgets('shows profile avatar in AppBar', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: emptySdk, appTitle: 'TestApp'),
+    ));
+    await tester.pump();
+
+    // CircleAvatar used for the profile button
+    expect(find.byType(CircleAvatar), findsOneWidget);
+  });
+
+  testWidgets('shows sync button in AppBar', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: emptySdk, appTitle: 'TestApp'),
+    ));
+    await tester.pump();
+
+    expect(find.byIcon(Icons.sync), findsOneWidget);
+  });
 }

--- a/test/mobile_home_screen_test.dart
+++ b/test/mobile_home_screen_test.dart
@@ -38,12 +38,16 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: MobileHomeScreen(sdk: emptySdk, appTitle: 'TestApp'),
     ));
-    // runAsync lets sqflite_ffi futures (real isolates) resolve, then pump rebuilds UI
+    // pumpAndSettle() cannot be used here: MobileHomeScreen._load() calls
+    // sqflite_ffi which runs on real OS isolates outside Flutter's test
+    // scheduler. pumpAndSettle() only drains microtasks/timers managed by
+    // that scheduler and would hang indefinitely waiting for I/O that it
+    // can never advance. runAsync() yields to the real event loop so the
+    // sqflite future resolves, then pump() triggers the setState rebuild.
     await tester.runAsync(() async {
-      await emptySdk.meta.getMobileFormGroups(); // warm up
+      await emptySdk.meta.getMobileFormGroups();
     });
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 50));
     expect(find.textContaining('No forms configured'), findsOneWidget);
   });
 
@@ -51,9 +55,18 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       home: MobileHomeScreen(sdk: sdkWithSurvey, appTitle: 'TestApp'),
     ));
+    // pumpAndSettle() cannot be used here: MobileHomeScreen._load() calls
+    // sqflite_ffi which runs on real OS isolates outside Flutter's test
+    // scheduler and would cause pumpAndSettle to hang indefinitely.
+    // runAsync() yields to the real event loop so the sqflite futures resolve.
+    // We await all the operations _load() performs (groups + per-doctype
+    // document query) so the widget's internal future has completed before
+    // we pump the rebuild.
     await tester.runAsync(() async {
-      // Wait for _load() to complete by waiting on the underlying async ops
-      await Future<void>.delayed(const Duration(milliseconds: 200));
+      final groups = await sdkWithSurvey.meta.getMobileFormGroups();
+      for (final doctype in groups.values.expand((l) => l)) {
+        await sdkWithSurvey.repository.getDocumentsByDoctype(doctype);
+      }
     });
     await tester.pump();
     expect(find.text('Survey'), findsOneWidget);

--- a/test/mobile_home_screen_test.dart
+++ b/test/mobile_home_screen_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frappe_mobile_sdk/frappe_mobile_sdk.dart';
+import 'package:frappe_mobile_sdk/src/database/app_database.dart';
+import 'package:frappe_mobile_sdk/src/database/entities/doctype_meta_entity.dart';
+import 'package:frappe_mobile_sdk/src/sdk/frappe_sdk.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+
+void main() {
+  setUpAll(() {
+    sqfliteFfiInit();
+    databaseFactory = databaseFactoryFfi;
+  });
+
+  late FrappeSDK emptySdk;
+  late FrappeSDK sdkWithSurvey;
+
+  setUp(() async {
+    final emptyDb = await AppDatabase.inMemoryDatabase();
+    emptySdk = FrappeSDK.forTesting('https://fake.test', emptyDb);
+
+    final surveyDb = await AppDatabase.inMemoryDatabase();
+    await surveyDb.doctypeMetaDao.insertDoctypeMeta(
+      DoctypeMetaEntity(
+        doctype: 'Survey Form',
+        modified: null,
+        serverModifiedAt: null,
+        isMobileForm: true,
+        metaJson: '{}',
+        groupName: 'Survey',
+        sortOrder: 0,
+      ),
+    );
+    sdkWithSurvey = FrappeSDK.forTesting('https://fake.test', surveyDb);
+  });
+
+  testWidgets('shows empty state when no groups configured', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: emptySdk, appTitle: 'TestApp'),
+    ));
+    // runAsync lets sqflite_ffi futures (real isolates) resolve, then pump rebuilds UI
+    await tester.runAsync(() async {
+      await emptySdk.meta.getMobileFormGroups(); // warm up
+    });
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 50));
+    expect(find.textContaining('No forms configured'), findsOneWidget);
+  });
+
+  testWidgets('renders group name and doctype name', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: sdkWithSurvey, appTitle: 'TestApp'),
+    ));
+    await tester.runAsync(() async {
+      // Wait for _load() to complete by waiting on the underlying async ops
+      await Future<void>.delayed(const Duration(milliseconds: 200));
+    });
+    await tester.pump();
+    expect(find.text('Survey'), findsOneWidget);
+    expect(find.text('Survey Form'), findsOneWidget);
+  });
+
+  testWidgets('shows app title in AppBar', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: MobileHomeScreen(sdk: emptySdk, appTitle: 'My App'),
+    ));
+    await tester.pump();
+    expect(find.text('My App'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
This PR introduces major improvements to form behavior, link field handling, metadata persistence, and SDK UI components.

Summary
The main goal of this branch is to improve conditional form behavior and section dependency handling, but the branch also includes several related enhancements across the SDK:

[form dependencies] Added client-side field change callbacks and improved depends_on evaluation for more complex form logic.
[link fields] Improved link option fetching and label resolution, including support for DocType title_field and better link_filters parsing.
[child tables and form UX] Improved child table row titles and ensured full document data is fetched before opening existing forms.
[SDK UI] Added a reusable MobileHomeScreen with grouped forms, sync controls, connectivity indicator, and customization hooks.
[metadata and database] Added grouped mobile form metadata support with schema migration and sort ordering.
[auth and reliability] Improved token refresh handling to avoid duplicate refresh attempts.
[testing] Added coverage for dependency evaluation, metadata behavior, SDK initialization for tests, and home screen behavior.
What Changed
Form dependency and computed field support
[field change callback] Added onFieldChange support in DocumentListScreen, FormScreen, and FrappeFormBuilder.
[computed fields] Enabled returning patched values from field changes so hidden/computed fields can be updated on the client.
[depends_on evaluator] Enhanced expression handling to support:
.includes(...) array syntax
bracket-aware splitting for && and ||
more robust parsing of conditional expressions
[value normalization] Added normalization for patched field values so form updates are applied in the correct runtime format for field types such as date, time, check, rating, select, duration, and table values.
[hidden field handling] Improved behavior when dependent/hidden fields need to be cleared after controlling values change.
Link field and child doctype improvements
[link option fetching] Updated link option requests to fetch all fields with wildcard selection so label resolution has access to the full document payload.
[title field labels] Resolved link labels using the DocType’s configured title_field, with fallback to common label fields and finally name.
[link filter parsing] Improved parsing of link_filters to support both:
eval:doc.field
eval: doc.field
[dependency extraction] Reused a shared evaluator utility for extracting eval:doc.* references more reliably.
[child table titles] Improved child table row titles by preferring the child DocType’s title_field when available.
Form opening and document loading
[full document fetch] For existing records, DocumentListScreen now attempts to fetch the full document payload from the API before opening the form.
[offline fallback] If the fetch fails, the form still falls back to the locally cached version.
Mobile home screen support
[new screen] Added a reusable MobileHomeScreen to the SDK and exported it publicly.
[grouped forms] Supports rendering mobile forms grouped by configuration metadata.
[sync controls] Added sync action handling and dirty-count visibility.
[status UI] Added connectivity badge and profile sheet support.
[customization hooks] Added hooks for overriding group headers, tiles, and sync behavior.
Metadata and database changes
[schema update] Extended doctype_meta with:
groupName
sortOrder
[migration] Added DB upgrade handling from version 1 to 2.
[grouped metadata access] Added getMobileFormGroups() in MetaService.
[ordering] Updated mobile form retrieval to return doctypes ordered by sortOrder.
[metadata persistence] Preserved groupName and sortOrder when updating stored metadata.
SDK and auth improvements
[testing support] Added FrappeSDK.forTesting(...) so tests can initialize the SDK with an in-memory database without depending on secure storage.
[current user access] Added a currentUser getter to the SDK.
[logout safety] logout() now throws if the SDK is not initialized instead of silently returning.
[token refresh] Added protection against duplicate refresh attempts in AuthService.
[request reliability] Adjusted request header creation in RestHelper so retry attempts rebuild headers correctly.
New field support
[HTML fields] Added HTML field rendering support using flutter_widget_from_html.
[field factory] Registered the new HTML field type in FieldFactory.
Why This Change
These updates improve the SDK in a few important ways:

[better conditional forms] Enables more realistic Frappe-style conditional logic and computed field behavior.
[better link UX] Makes link options and child rows display meaningful labels instead of raw IDs.
[better mobile configuration support] Adds grouped mobile forms and a reusable SDK home screen.
[better reliability] Improves token refresh flow and testability.
[better parity with server config] Preserves more mobile form metadata and honors server-defined ordering/grouping.
Testing
Added or updated tests for:

[depends_on evaluator] complex dependency expressions and .includes(...)
[meta service] metadata persistence, grouping, and DAO round-trip behavior
[SDK] test initialization via FrappeSDK.forTesting
[mobile home screen] widget behavior and home screen interactions