### PR TITLE
fix(form): prevent null formValues from overwriting child table data …

### DIFF
--- a/lib/src/ui/widgets/fields/child_table_field.dart
+++ b/lib/src/ui/widgets/fields/child_table_field.dart
@@ -306,24 +306,16 @@ class _ChildTableSheetState extends State<_ChildTableSheet> {
           ),
           const Divider(height: 1),
           Expanded(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(16),
-              child: ConstrainedBox(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.of(context).size.height,
-                ),
-                child: widget.formBuilder(
-                  widget.childMeta,
-                  widget.initialData,
-                  (data) => widget.onSubmit(data),
-                  registerSubmit: (fn) {
-                    _submitFn = fn;
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      if (mounted) setState(() {});
-                    });
-                  },
-                ),
-              ),
+            child: widget.formBuilder(
+              widget.childMeta,
+              widget.initialData,
+              (data) => widget.onSubmit(data),
+              registerSubmit: (fn) {
+                _submitFn = fn;
+                WidgetsBinding.instance.addPostFrameCallback((_) {
+                  if (mounted) setState(() {});
+                });
+              },
             ),
           ),
           const Divider(height: 1),

--- a/lib/src/ui/widgets/form_builder.dart
+++ b/lib/src/ui/widgets/form_builder.dart
@@ -946,7 +946,14 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
     }
 
     // Then override with any form values (user input takes precedence)
-    completeFormData.addAll(formValues);
+    // But skip null values for Table fields — ChildTableField is not a
+    // FormBuilderField, so state.value returns null for Table fields even
+    // when _formData has the actual child row data.
+    for (final entry in formValues.entries) {
+      if (entry.value != null) {
+        completeFormData[entry.key] = entry.value;
+      }
+    }
 
     widget.onSubmit?.call(completeFormData);
   }
@@ -968,7 +975,11 @@ class _FrappeFormBuilderState extends State<FrappeFormBuilder>
             (field.fieldtype == 'Check' ? 0 : '');
       }
     }
-    complete.addAll(formValues);
+    for (final entry in formValues.entries) {
+      if (entry.value != null) {
+        complete[entry.key] = entry.value;
+      }
+    }
     return complete;
   }
 


### PR DESCRIPTION
…in _formData

- Remove SingleChildScrollView wrapper from ChildTableSheet (formBuilder handles its own scrolling)
- Skip null entries when merging formValues into completeFormData in _submit()
- Skip null entries when merging formValues into complete in _getCurrentFormData()
- Prevents ChildTableField's null state.value from erasing actual child row data stored in _formData