### PR TITLE
feat(sync): inject isOnlineOverride into SyncService.isOnline()

### DIFF
--- a/lib/src/sdk/frappe_sdk.dart
+++ b/lib/src/sdk/frappe_sdk.dart
@@ -139,7 +139,25 @@ class FrappeSDK {
     _modeNotifier?.value = next;
   }
 
-  FrappeSDK({required this.baseUrl, this.databaseAppName});
+  FrappeSDK({
+    required this.baseUrl,
+    this.databaseAppName,
+    this.isOnlineOverride,
+  });
+
+  /// Optional override for the SDK's connectivity probe (see
+  /// [SyncService.isOnline]). When set, the platform's
+  /// `connectivity_plus` check is replaced — the override decides whether
+  /// `pullSync`/`pullSyncMany`/`pushSync` see the device as online.
+  ///
+  /// Production wiring should leave this null. The legitimate dev use is
+  /// the emulator+`adb reverse` workflow, where the platform classifies
+  /// the network as `none` despite HTTP working fine. Setting
+  /// `isOnlineOverride: () async => true` in dev keeps sync running.
+  ///
+  /// If the override throws, [SyncService.isOnline] falls back to the
+  /// platform probe.
+  final Future<bool> Function()? isOnlineOverride;
 
   /// Test-only constructor: accepts a pre-built [AppDatabase] (e.g. in-memory).
   /// Wires all services directly without calling [initialize()].
@@ -157,7 +175,8 @@ class FrappeSDK {
       enabled: true,
       isPersisted: true,
     ),
-  }) : databaseAppName = null {
+  }) : databaseAppName = null,
+       isOnlineOverride = null {
     _database = database;
     _modeNotifier = OfflineModeNotifier(offlineMode);
     _syncCompleteController = StreamController<void>.broadcast();
@@ -341,6 +360,7 @@ class FrappeSDK {
       getMobileUuid: _resolveMobileUuid,
       offlineModeNotifier: _modeNotifier!,
       pushRunner: () => _pushEngine!.runOnce(),
+      isOnlineOverride: isOnlineOverride,
     );
     // Build UnifiedResolver — single read path for all offline queries.
     // Probe connectivity once here AND subscribe to the platform

--- a/lib/src/services/sync_service.dart
+++ b/lib/src/services/sync_service.dart
@@ -64,15 +64,45 @@ class SyncService {
     ),
     OfflineModeNotifier? offlineModeNotifier,
     Future<void> Function()? pushRunner,
+    Future<bool> Function()? isOnlineOverride,
   }) : _getMobileUuid = getMobileUuid,
        _modeNotifier = offlineModeNotifier ?? OfflineModeNotifier(offlineMode),
-       _pushRunner = pushRunner;
+       _pushRunner = pushRunner,
+       _isOnlineOverride = isOnlineOverride;
+
+  /// Optional override for the connectivity probe.
+  ///
+  /// When supplied, [isOnline] calls this instead of `connectivity_plus`.
+  /// The override returning `true` lets [pullSync] / [pullSyncMany] /
+  /// [pushSync] proceed past their connectivity guard even on transports
+  /// the platform plugin doesn't classify as `mobile | wifi | ethernet`
+  /// (notably `adb reverse` tunnels during emulator development, where
+  /// the link reads as `none` despite HTTP being fully functional).
+  ///
+  /// Production callers should leave this null and rely on the platform
+  /// probe. Dev/test wiring is the legitimate use case.
+  ///
+  /// If the override throws, [isOnline] logs the failure and falls
+  /// through to the platform probe — a buggy override won't brick sync.
+  final Future<bool> Function()? _isOnlineOverride;
 
   /// Check if device is online.
   /// Returns false when offline mode is disabled, regardless of connectivity,
   /// so callers can use this method without a separate mode guard.
   Future<bool> isOnline() async {
     if (!offlineMode.enabled) return false;
+    final override = _isOnlineOverride;
+    if (override != null) {
+      try {
+        return await override();
+      } catch (e, st) {
+        // ignore: avoid_print
+        print(
+          'SyncService.isOnline: isOnlineOverride threw, '
+          'falling back to platform probe — $e\n$st',
+        );
+      }
+    }
     final connectivityResult = await Connectivity().checkConnectivity();
     return connectivityResult.contains(ConnectivityResult.mobile) ||
         connectivityResult.contains(ConnectivityResult.wifi) ||


### PR DESCRIPTION
## What

Adds an optional `Future<bool> Function()? isOnlineOverride` parameter on `SyncService` and `FrappeSDK`. When set, the override replaces the `connectivity_plus` probe inside `SyncService.isOnline()`. When unset (the default), behaviour is unchanged.

## Why this is needed

`SyncService.isOnline()` calls `Connectivity().checkConnectivity()` directly and only accepts `mobile | wifi | ethernet`:

```dart
Future<bool> isOnline() async {
  if (!offlineMode.enabled) return false;
  final connectivityResult = await Connectivity().checkConnectivity();
  return connectivityResult.contains(ConnectivityResult.mobile) ||
      connectivityResult.contains(ConnectivityResult.wifi) ||
      connectivityResult.contains(ConnectivityResult.ethernet);
}
```

On Android emulators with `adb reverse`, the platform reports `ConnectivityResult.none` because the tunnel isn't a recognised network type — even though HTTP traffic to the bench flows fine. `pullSync` / `pullSyncMany` / `pushSync` then early-exit with `noConnectivity` and refuse to run.

Today consumers have **no app-side escape**:
- The `ConnectivityWatcher` isn't exported from the barrel.
- `SyncService.isOnline()` bypasses the watcher anyway — it probes the plugin directly.
- The `FrappeSDK` constructor takes no hook to replace the probe.

The only workaround until now has been to bypass `SyncService.pullSync` / `pullSyncMany` entirely from the consumer app — losing the SDK's delta cursors, page lookahead, and RESUME-on-crash semantics in the process. We were carrying that bypass for ~2 weeks in the Swasti V3 mobile app before this PR.

## What this PR changes

1. `SyncService` constructor accepts `Future<bool> Function()? isOnlineOverride`.
2. `SyncService.isOnline()` calls the override first when set; falls back to the platform probe on throw (with a logged warning) so a buggy override can't brick sync.
3. `FrappeSDK()` accepts `isOnlineOverride` and threads it through to `SyncService`.
4. The `FrappeSDK.forTesting` constructor initialises the field to `null` in its initializer list to keep tests source-compatible.

## Backward compatibility

- Default value is `null` — existing `FrappeSDK(baseUrl: ...)` and `SyncService(...)` call sites behave exactly as before.
- The existing private `_isOnlineOverrideForTesting` test seam in `frappe_sdk.dart` is unchanged.

## Safety notes

- `offlineMode.enabled` gate runs first; the override does not bypass an explicit offline-mode opt-out.
- If the override throws, `isOnline()` logs the failure and falls through to the platform probe.

## Intended use

Dev builds that talk to a local bench via `adb reverse`:

```dart
final sdk = FrappeSDK(
  baseUrl: 'http://10.0.2.2:8001',
  isOnlineOverride: () async => true, // dev-only
);
```

Production callers should leave `isOnlineOverride` null and rely on the platform probe.

## Tests

183 sync-related tests pass unchanged on this branch (`test/sync/`, `test/concurrency/sync_mutex_test.dart`, `test/services/sync_engine_builder_send_test.dart`). No new tests added — the change is opt-in and the existing suite covers the default path.
