### PR TITLE
feat(utils): export DependsOnEvaluator on the public barrel

### DIFF
--- a/lib/frappe_mobile_sdk.dart
+++ b/lib/frappe_mobile_sdk.dart
@@ -135,3 +135,4 @@ export 'src/ui/dialogs/force_logout_confirm.dart' show showForceLogoutConfirm;
 // Utils (debug tracer + user-friendly errors)
 export 'src/api/utils.dart' show extractErrorMessage, toUserFriendlyMessage;
 export 'src/utils/api_tracer.dart' show ApiTracer;
+export 'src/utils/depends_on_evaluator.dart' show DependsOnEvaluator;


### PR DESCRIPTION
## What

One-line addition to the SDK barrel:

```dart
export 'src/utils/depends_on_evaluator.dart' show DependsOnEvaluator;
```

No code in `src/utils/depends_on_evaluator.dart` changes; only its visibility.

## Why this is needed

`DependsOnEvaluator` evaluates Frappe's `depends_on` / `mandatory_depends_on` expressions. The class is already mature canonical infrastructure for the SDK itself — referenced **9 times internally**:

- `src/ui/widgets/form_builder.dart` × 7 (visibility, mandatoriness, read-only, tab/section evaluation)
- `src/services/link_option_service.dart` × 2 (`extractEvalDocField`)

The class docstring already calls out the public-API intent:

> **Trust boundary:** expressions evaluated here come from server-side DocType meta configured by Frappe admins, not from end-user input. This evaluator is NOT sandboxed — do not pass user-supplied strings to `evaluate`.

The class lives in `src/utils/` only because it was never explicitly exported. Consumers reaching into the SDK to use it need `// ignore: implementation_imports`.

## Who needs this

Apps that **own their own form layer** rather than rendering through `FrappeFormBuilder` need the same evaluator on the UI side. Concretely: any consumer that:

1. Uses the SDK's data layer (`OfflineRepository`, `SyncService`, `UnifiedResolver`) for offline-first save / pull / push;
2. But builds their own widget tree for forms (because of design-system requirements, custom layouts driven by client-locked design specs, etc.);

… needs `depends_on` / `mandatory_depends_on` semantics on the UI side to match the SDK's data-layer expectations.

Re-implementing the evaluator locally would mean duplicating ~150 LOC of expression parsing (the `eval:` prefix strip, AND/OR splits outside brackets, six comparison operators, `.includes([...])` patterns, nested-paren handling). Every time the SDK extends the supported expression syntax, the consumer's duplicate would silently drift.

Exporting the symbol from the SDK's public barrel keeps semantics aligned with the upstream evaluator, with no code drift surface.

## Why not introduce a new abstract interface

The existing class is the contract. There's nothing implementation-specific about evaluating a string against a `Map<String, dynamic>` — that's exactly what the SDK does internally too. A new interface would just shadow the existing class without adding value.

## Tests

No new tests; the change is visibility-only. The existing evaluator tests in `test/utils/depends_on_evaluator_test.dart` (if any) and the 7+2 internal call sites continue to work unchanged.
