### PR TITLE
feat: add Aadhaar number validation utility

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -771,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1064,10 +1064,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/utils/aadhaar_validator.dart
+++ b/lib/utils/aadhaar_validator.dart
@@ -1,0 +1,14 @@
+class AadhaarValidator {
+  static bool isValid(String? aadhaarNumber) {
+    if (aadhaarNumber == null || aadhaarNumber.isEmpty) {
+      return false;
+    }
+
+    String cleanNumber = aadhaarNumber.replaceAll(RegExp(r'[\s-]'), '');
+
+    // Aadhaar Regex
+    RegExp aadhaarRegExp = RegExp(r'^[2-9][0-9]{11}$');
+
+    return aadhaarRegExp.hasMatch(cleanNumber);
+  }
+}

--- a/test/utils/aadhaar_validator_test.dart
+++ b/test/utils/aadhaar_validator_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:frappe_mobile_sdk/utils/aadhaar_validator.dart';
+
+
+void main() {
+  group('AadhaarValidator Tests', () {
+    test('Geçerli bir Aadhaar numarası true dönmeli', () {
+      expect(AadhaarValidator.isValid('234567890123'), isTrue);
+    });
+
+    test('Boşluk veya tire içeren geçerli numara true dönmeli', () {
+      expect(AadhaarValidator.isValid('2345 6789 0123'), isTrue);
+      expect(AadhaarValidator.isValid('2345-6789-0123'), isTrue);
+    });
+
+    test('12 haneden eksik veya fazla olanlar false dönmeli', () {
+      expect(AadhaarValidator.isValid('23456789012'), isFalse); // 11 hane
+      expect(AadhaarValidator.isValid('2345678901234'), isFalse); // 13 hane
+    });
+
+    test('0 veya 1 ile başlayan numaralar false dönmeli', () {
+      expect(AadhaarValidator.isValid('034567890123'), isFalse);
+      expect(AadhaarValidator.isValid('134567890123'), isFalse);
+    });
+
+    test('Boş veya null değerler false dönmeli', () {
+      expect(AadhaarValidator.isValid(''), isFalse);
+      expect(AadhaarValidator.isValid(null), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Description
This PR introduces the `AadhaarValidator` utility class to validate Indian Aadhaar numbers based on the standard 12-digit requirement format.

Fixes #66

## Changes Made
- Added a new `aadhaar_validator.dart` file inside the `lib/utils/` directory.
- Implemented static method `isValid(String? aadhaarNumber)`.
- Added regex validation to ensure the number is exactly 12 digits long and does not start with 0 or 1.
- Handled empty/null inputs and stripped spaces/hyphens for accurate validation.

## Type of Contribution
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring