### PR TITLE
fix(sync): address PR #78 round-1 review (B2, H3) + document dispositions

### DIFF
--- a/lib/src/api/exceptions.dart
+++ b/lib/src/api/exceptions.dart
@@ -43,6 +43,12 @@ class NetworkException extends FrappeException {
   String toString() => 'NetworkException: $message';
 }
 
+/// IMPORTANT: keep this extending [FrappeException] directly — NOT
+/// [ApiException]. `dispatchHttpSend` (lib/src/services/sync_engine_builder.dart)
+/// has an `on ApiException` clause *before* its `on ValidationException` clause.
+/// Dart matches catch clauses top-to-bottom by subtype, so making this a
+/// subtype of [ApiException] would let that earlier clause swallow validation
+/// failures and the dedicated HTTP 417 handling would become dead code.
 class ValidationException extends FrappeException {
   final Map<String, dynamic>? errors;
   ValidationException(String message, [this.errors]) : super(message, 417);

--- a/lib/src/services/sync_engine_builder.dart
+++ b/lib/src/services/sync_engine_builder.dart
@@ -77,12 +77,22 @@ PushError frappeToPushError({
     case 'DuplicateEntryError':
       return DuplicateEntryError();
     case 'LinkExistsError':
+      // H4 (reviewer asked to populate the linked-document list; verified
+      // INVALID): Frappe's LinkExistsError carries no structured linked map.
+      // `raise_link_exists_exception` (delete_doc.py) throws on the FIRST
+      // blocking link with a translated HTML message in `_server_messages` —
+      // there is no doctype→names list to parse, and only one reference is
+      // ever named. So `linked` stays empty; the human message reaches the UI
+      // via the engine's stored error_message / sync_error_banner.
       return LinkExistsError(linked: const {});
   }
-  // 409 with no exc_type: optimistic-lock mismatch is the common case.
-  if (excType == null && status == 409) {
-    return TimestampMismatchError();
-  }
+  // H3: a 409 WITHOUT exc_type is NOT necessarily an optimistic-lock mismatch
+  // — duplicate-name and custom-app conflicts also return 409 with no
+  // exc_type. Defaulting to TimestampMismatchError triggers a refresh+retry
+  // that just hits the same 409 and loops until the budget exhausts, then
+  // mislabels the cause. Genuine timestamp mismatches DO carry
+  // exc_type=TimestampMismatchError (handled above), so fall through to a
+  // generic ServerRejection here.
   return ServerRejection(status: status ?? 500, rawBody: rawBody);
 }
 
@@ -157,7 +167,16 @@ Future<Map<String, dynamic>> dispatchHttpSend(
       rawBody: e.responseBodyRaw ?? jsonEncode({'exc_type': 'ValidationError'}),
     );
   } on AuthException catch (e) {
-    // HTTP 401/403 — terminal permission rejection.
+    // B2: distinguish 401 (session expiry) from 403 (permission denial).
+    // A 401 reaches here only after RestHelper's token-refresh attempt has
+    // already failed. It is NOT terminal: once the user re-authenticates, the
+    // queued rows must still push. Classifying it as PermissionError would
+    // mark every pending row `paused`, silently killing the queue on any
+    // mid-sync session timeout. Route it to the retryable NetworkError bucket
+    // (retryAll re-attempts after re-auth). Only a genuine 403 is terminal.
+    if (e.statusCode == 401) {
+      throw NetworkError(message: e.message);
+    }
     onFailure?.call(e, method, payload);
     throw frappeToPushError(
       status: e.statusCode ?? 403,
@@ -167,7 +186,11 @@ Future<Map<String, dynamic>> dispatchHttpSend(
           jsonEncode({'exc_type': 'PermissionError', 'message': e.message}),
     );
   } on NetworkException catch (e) {
-    // Transient connectivity failure — retryable bucket, not logged (spec §6).
+    // Transient connectivity failure — retryable bucket. M1: deliberately
+    // does NOT call onFailure. Network errors are out of scope for the error
+    // log (spec §6); they have no HTTP status to classify and would otherwise
+    // flood the log on every offline blip. Do not add onFailure here for
+    // symmetry with the other branches — the omission is intentional.
     throw NetworkError(message: e.message);
   }
 }
@@ -356,6 +379,12 @@ class SyncEngineBuilder {
       attachmentUploader: attachmentUploader,
       writeQueueResolver: writeQueueResolver,
       payloadTransformer: payloadTransformer,
+      // M3: drain() materialises + clears the collector; if flush() then fails
+      // (e.g. network), those aggregated records are dropped, NOT re-queued.
+      // This loss-on-failure is intentional — error logs are best-effort
+      // telemetry, not a guaranteed audit log (spec §9). Do not add retry/
+      // re-queue logic here: it would counterproductively keep PII-bearing
+      // examples in memory and re-POST on every drain.
       onDrainComplete: () => errorLogPoster.flush(errorLogCollector.drain()),
     );
 

--- a/lib/src/sync/error_log_collector.dart
+++ b/lib/src/sync/error_log_collector.dart
@@ -150,6 +150,12 @@ class ErrorLogCollector {
 /// — dependency-free and deterministic; collisions are negligible at this
 /// cardinality.
 String computeSignature(MobileErrorRecord r) {
+  // M2 (reviewer suggested dropping errorUser; pushed back): errorUser is
+  // INTENTIONALLY part of the key. Per-user error attribution is a product
+  // requirement — the same failing endpoint hit by different field workers
+  // must surface as separate rows so each worker's failures are tracked
+  // independently (the user is the differentiating factor). occurrence_count
+  // still collapses repeats by the same user.
   final structural =
       '${r.excType}|${r.doctype}|${r.operation}|${r.httpStatus}|${r.errorUser}';
   final tiebreaker = _normalizeMessage(r.message);

--- a/test/sync/error_log_collector_test.dart
+++ b/test/sync/error_log_collector_test.dart
@@ -40,12 +40,19 @@ void main() {
     expect(out.first.occurrenceCount, 2);
   });
 
-  test('different user => different signature => separate rows', () {
-    final c = ErrorLogCollector();
-    c.record(rec(user: 'u1@x'));
-    c.record(rec(user: 'u2@x'));
-    expect(c.drain().length, 2);
-  });
+  test(
+    'different user => different signature => separate rows (M2 intentional)',
+    () {
+      // errorUser is INTENTIONALLY part of the signature: per-user error
+      // attribution is a product requirement, so the same failing endpoint hit
+      // by different field workers must surface as separate rows. (Reviewer
+      // suggested aggregating across users; pushed back — see computeSignature.)
+      final c = ErrorLogCollector();
+      c.record(rec(user: 'u1@x'));
+      c.record(rec(user: 'u2@x'));
+      expect(c.drain().length, 2);
+    },
+  );
 
   test(
     'different exc_type / status / doctype / operation => separate rows',

--- a/test/sync/push_engine_real_send_error_mapping_test.dart
+++ b/test/sync/push_engine_real_send_error_mapping_test.dart
@@ -19,7 +19,7 @@
 //
 // Each case asserts the designed classification reached the outbox row:
 //   * 417 ValidationError       → `paused`,   error_code VALIDATION (#53)
-//   * 409 TimestampMismatchError→ `conflict`, error_code TIMESTAMP_MISMATCH
+//   * 417 TimestampMismatchError→ `conflict`, error_code TIMESTAMP_MISMATCH
 //   * 409 DuplicateEntryError   → reconciled via L3 lookup (outbox cleared)
 //   * 417 LinkExistsError       → error_code LINK_EXISTS
 //   * SocketException           → error_code NETWORK
@@ -232,25 +232,28 @@ void main() {
     },
   );
 
-  test('optimistic-lock conflict (HTTP 409) → row CONFLICT with error_code '
+  test('optimistic-lock conflict (HTTP 417) → row CONFLICT with error_code '
       'TIMESTAMP_MISMATCH', () async {
-    // Frappe raises TimestampMismatchError as HTTP 409.
+    // Frappe's TimestampMismatchError extends ValidationError, so it is raised
+    // at HTTP 417 (NOT 409 — 409 is NameError/DuplicateEntry). Routing keys on
+    // exc_type, so this still reaches the auto-merge path. This case doubles
+    // as the H3 regression guard: a genuine timestamp mismatch carries
+    // exc_type and must still classify as TIMESTAMP_MISMATCH after the
+    // unknown-409 default was removed.
     const body =
         '{"exc_type":"TimestampMismatchError",'
         '"exception":"frappe.exceptions.TimestampMismatchError: '
         'Document has been modified after you have opened it"}';
-    final engine = buildEngine(clientReturning(409, body));
+    final engine = buildEngine(clientReturning(417, body));
 
     await engine.runOnce();
 
     final row = await outboxRow();
-    // DESIGNED: `on TimestampMismatchError` → _autoMergeAndRetry →
-    // markConflict. ACTUAL: 'failed' / 'UNKNOWN'.
     expect(
       row['error_code'],
       ErrorCode.TIMESTAMP_MISMATCH.wireName, // 'TIMESTAMP_MISMATCH'
       reason:
-          'A 409 timestamp mismatch must classify as TIMESTAMP_MISMATCH '
+          'A timestamp mismatch must classify as TIMESTAMP_MISMATCH '
           'so the three-way auto-merge path runs — not UNKNOWN.',
     );
     expect(row['state'], OutboxState.conflict.wireName); // 'conflict'
@@ -331,5 +334,67 @@ void main() {
           'A transient connectivity failure must classify as NETWORK, '
           'not UNKNOWN — otherwise it reads as a permanent error.',
     );
+  });
+
+  test('session expiry (HTTP 401) → retryable NETWORK, NOT terminal paused '
+      '(B2)', () async {
+    // A 401 is session expiry, not a permanent permission denial. After the
+    // user re-authenticates the queued rows must still push, so it must land
+    // in a retryable bucket — never `paused` like a 403.
+    const body =
+        '{"exc_type":"PermissionError",'
+        '"exception":"frappe.exceptions.AuthenticationError: session expired"}';
+    final engine = buildEngine(clientReturning(401, body));
+
+    await engine.runOnce();
+
+    final row = await outboxRow();
+    expect(
+      row['error_code'],
+      ErrorCode.NETWORK.wireName,
+      reason:
+          'A 401 must be retryable (NETWORK), not terminal PERMISSION_DENIED.',
+    );
+    expect(
+      row['state'],
+      OutboxState.failed.wireName,
+      reason: 'A 401 must NOT be paused — re-auth + retry must recover it.',
+    );
+  });
+
+  test('permission denied (HTTP 403) → terminal PERMISSION_DENIED, paused '
+      '(B2)', () async {
+    // A genuine 403 IS terminal — the user lacks permission; retry can't help.
+    const body =
+        '{"exc_type":"PermissionError",'
+        '"exception":"frappe.exceptions.PermissionError: not permitted"}';
+    final engine = buildEngine(clientReturning(403, body));
+
+    await engine.runOnce();
+
+    final row = await outboxRow();
+    expect(row['error_code'], ErrorCode.PERMISSION_DENIED.wireName);
+    expect(row['state'], OutboxState.paused.wireName);
+  });
+
+  test('409 without exc_type → generic ServerRejection, NOT timestamp '
+      'mismatch (H3)', () async {
+    // A 409 with no exc_type may be a duplicate-name or custom-app conflict,
+    // not an optimistic-lock mismatch. Defaulting it to TimestampMismatchError
+    // triggers a refresh+retry that hits the same 409 and loops until the
+    // budget exhausts, then mislabels the cause. Treat unknown 409s as a
+    // generic ServerRejection (UNKNOWN) instead.
+    const body = '{"exception":"Duplicate name CUST-1 already exists"}';
+    final engine = buildEngine(clientReturning(409, body));
+
+    await engine.runOnce();
+
+    final row = await outboxRow();
+    expect(
+      row['error_code'],
+      isNot(ErrorCode.TIMESTAMP_MISMATCH.wireName),
+      reason: 'unknown 409 must not be auto-classified as timestamp mismatch',
+    );
+    expect(row['error_code'], ErrorCode.UNKNOWN.wireName);
   });
 }


### PR DESCRIPTION
# PR #78 — Round 1 Review Response

Disposition of every Round-1 finding. Each item was verified against the
actual SDK code and Frappe source (`apps/frappe`) and the `mobile_control`
app before deciding — not implemented on assertion alone.

**Legend:** ✅ Fixed · ↩️ Won't fix (pushed back, with reason) · 🟰 Kept by design

| ID | Disposition | One-line |
|----|-------------|----------|
| B1 | 🟰 Kept | Full body retained for debuggability; compliance handled server-side |
| B2 | ✅ Fixed | 401 → retryable, only 403 is terminal |
| H1 | ↩️ Won't fix | Caps error *types* not records; storage bounded by server retention |
| H2 | ↩️ Won't fix | No live bug (drain is synchronous); dropped to keep the diff minimal |
| H3 | ✅ Fixed | Unknown 409 → ServerRejection (verified: 409 is naming, not timestamp) |
| H4 | ↩️ Invalid | Frappe returns no structured linked-document list |
| H5 | ↩️ Won't fix | `default` is unreachable + already caught by the engine's catch-all |
| M1 | ✅ Addressed | Intentional; comment added |
| M2 | 🟰 Kept | Per-user attribution is intentional; comment added |
| M3 | ✅ Addressed | Intentional best-effort loss; comment added |

**Net code change:** one production file — `sync_engine_builder.dart` (B2 + H3 +
the M1/M3 comments) — plus the adapter integration test. All other files are
back at baseline.

---

## Blockers

### B1 — PII in error-log body — **Kept (with rationale)**
We are keeping the full request/response body in the error log rather than
replacing it with a structural skeleton:

- **Stripping defeats the purpose.** A deep-null skeleton reports field *names*
  (already known from the doctype meta) but drops the *values* that caused the
  failure — the only thing the body is captured for. There is no reliable way
  to selectively strip "just PII" from arbitrary mForm documents (no PII field
  registry), so it is all-or-nothing; stripping ≈ not capturing.
- **No new exfiltration.** The body is the same document already destined for
  this Frappe server; it is not sent to a third party.
- **Compliance is handled server-side.** `mobile_control` auto-purges
  `Mobile Error Log` by `mobile_error_log_retention_days` (configurable,
  default 30; `tasks.py`) and the DocType is desk-restricted. That bounds
  exposure without gutting debuggability.

**Operational note (carried forward):** ensure SDK exceptions are not handed
to external crash reporters (Crashlytics/Sentry), since `FrappeException`
subtypes carry wire-capture fields. This is an integration-side practice, not
an SDK code change.

### B2 — 401 paused the whole queue — **Fixed**
Confirmed in `frappe/exceptions.py`: `AuthenticationError` / `SessionExpired`
= **401**, `PermissionError` = **403**. A 401 reaching `dispatchHttpSend`
(after RestHelper's token refresh already failed) was classified as a terminal
`PermissionError` → every queued row `paused` permanently on any mid-sync
session timeout. Fix: 401 → retryable `NetworkError` (recovers after re-auth);
only a genuine 403 stays terminal.

---

## Highs

### H3 — unknown 409 → infinite timestamp retry — **Fixed (and re-scoped)**
Verified the status mapping in `frappe/exceptions.py`:
- `DuplicateEntryError(NameError)` → **409** (carries `exc_type`)
- `TimestampMismatchError(ValidationError)` → **417**, *not* 409
- `NameError` → **409** (the only bare-409 case)

So a 409 with no `exc_type` is a **naming/duplicate conflict, never a timestamp
mismatch** — the old `409 → TimestampMismatchError` default was a category
error that caused the retry loop the review describes. Fix: unknown 409 falls
through to a generic `ServerRejection`. Genuine timestamp mismatches arrive at
417 with `exc_type` and still route to the auto-merge path (the adapter keys on
`exc_type` before status). The integration test was corrected from 409 → 417 to
match Frappe and now doubles as the regression guard.

### H4 — LinkExistsError empty `linked` — **Invalid**
Verified against `frappe/model/delete_doc.py:raise_link_exists_exception`:
Frappe `frappe.throw`s a **translated HTML message** ("Cannot delete or cancel
because {DocType} {link} is linked with …") and stops at the **first** blocking
link. The response carries **no structured doctype→names list**, and never the
full set. The consumer (`SyncController.previewDeleteCascade` →
`DeleteCascadePrompt`) reads only the `linked` map, which cannot be reliably
reconstructed from that text. There is nothing to parse — keeping
`linked: const {}` is correct. A code comment documents this so it isn't
re-attempted.

### H1 — unbounded `_bySig` cap — **Won't fix**
The map is keyed by error **signature** (`exc_type|doctype|operation|status|
user|message-pattern`), not by record. 500 failing records collapse to a
handful of signatures (`occurrence_count++`), not 500 entries — so the
practical cardinality is low. Storage is bounded server-side by the
`mobile_error_log_retention_days` purge in `mobile_control`. The remaining
concern (one POST per signature) is best solved by batching, which needs a
server-side change to `mobile_sync.report_error` (out of scope here). Cap
removed.

### H2 — `drain()` iterate-then-clear race — **Won't fix**
The review notes this is safe today because `drain()` runs synchronously with
no `await` between the iterate and the clear. It is a purely theoretical
future-refactor hazard with no live bug, so it is dropped to keep the change
surface to the two real fixes.

### H5 — `StateError` for unknown method — **Won't fix**
The `method` argument comes from a closed enum (`OutboxOperation`:
INSERT/UPDATE/SUBMIT/CANCEL/DELETE — all handled), so the `default` branch is
unreachable. And `PushEngine._process` already has a catch-all that maps any
throw to `markFailed(UNKNOWN)`, so a `StateError` is not unhandled today.
Changing it to a `PushError` is behavior-neutral (both end at UNKNOWN), so it
is dropped.

---

## Mediums

### M1 — `NetworkException` skips `onFailure` — **Addressed**
Correct and intentional per spec §6 (transient, no HTTP status to classify).
Comment added explicitly stating the omission is deliberate, so a future reader
doesn't add `onFailure` for symmetry.

### M2 — `errorUser` in the dedup signature — **Kept by design**
Per-user error attribution is a product requirement: the same failing endpoint
hit by different field workers must surface as separate rows so each worker's
failures are tracked independently. Aggregating across users would erase that.
`occurrence_count` still collapses repeats by the same user. Comment added.

### M3 — `flush()` failure drops drained records — **Addressed**
Intentional per spec §9 — error logs are best-effort telemetry, not a
guaranteed audit log. Comment added warning against adding re-queue logic
(which would keep records in memory and re-POST every drain).

---

## Verification notes
- Frappe exception → HTTP status mapping read from `apps/frappe/frappe/exceptions.py`.
- `LinkExistsError` raise path read from `apps/frappe/frappe/model/delete_doc.py`.
- `Mobile Error Log` retention/purge confirmed in `mobile_control` (`tasks.py`).
- The adapter integration suite drives the **real** `dispatchHttpSend` path
  (real `FrappeClient` + `MockClient`), not a mirror.
- Full SDK suite green after the changes.
