### PR TITLE
fix: harden depends_on/link_filters parsing and child-table Save button loading state

### DIFF
--- a/lib/src/ui/widgets/fields/child_table_field.dart
+++ b/lib/src/ui/widgets/fields/child_table_field.dart
@@ -356,7 +356,17 @@ class _ChildTableSheetState extends State<_ChildTableSheet> {
                   const SizedBox(width: 8),
                   FilledButton.icon(
                     onPressed: _submitFn != null ? () => _submitFn!() : null,
-                    icon: const Icon(Icons.check, size: 20),
+                    icon: _submitFn != null
+                        ? const Icon(Icons.check, size: 20)
+                        : const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              valueColor:
+                                  AlwaysStoppedAnimation<Color>(Colors.white),
+                            ),
+                          ),
                     label: const Text('Save'),
                   ),
                 ],

--- a/lib/src/utils/depends_on_evaluator.dart
+++ b/lib/src/utils/depends_on_evaluator.dart
@@ -180,7 +180,14 @@ class DependsOnEvaluator {
       expr = value.substring(5).trimLeft();
     }
     String fieldName = _extractFieldName(expr);
-    return expr == fieldName ? null : fieldName;
+    if (expr != fieldName) return fieldName;
+    // The whole expression isn't a bare `doc.field` reference (e.g. it's
+    // wrapped in a JS call like `(doc.x||'').replace(/.../, '')`). Fall back
+    // to finding the first `doc.<field>` reference anywhere in the string so
+    // dependent-field detection (used for the link field's "select X first"
+    // UX) still works for these more complex link_filters expressions.
+    final match = RegExp(r'doc\.([A-Za-z_][A-Za-z0-9_]*)').firstMatch(expr);
+    return match?.group(1);
   }
 
   static dynamic _extractValue(String expr) {

--- a/lib/src/utils/depends_on_evaluator.dart
+++ b/lib/src/utils/depends_on_evaluator.dart
@@ -185,6 +185,12 @@ class DependsOnEvaluator {
 
   static dynamic _extractValue(String expr) {
     expr = expr.trim();
+    // Strip a trailing statement terminator — Frappe depends_on expressions
+    // are sometimes authored as `eval:doc.x == 1;` with a trailing semicolon,
+    // which otherwise breaks the numeric-literal regexes below.
+    if (expr.endsWith(';')) {
+      expr = expr.substring(0, expr.length - 1).trim();
+    }
     // Remove quotes if present
     if ((expr.startsWith('"') && expr.endsWith('"')) ||
         (expr.startsWith("'") && expr.endsWith("'"))) {

--- a/test/depends_on_evaluator_test.dart
+++ b/test/depends_on_evaluator_test.dart
@@ -71,6 +71,33 @@ void main() {
         );
         expect(DependsOnEvaluator.evaluate('eval:doc.active', {}), isFalse);
       });
+
+      test('trailing semicolon on int comparison is stripped', () {
+        expect(
+          DependsOnEvaluator.evaluate(
+            'eval:doc.enabled_flag == 1;',
+            {'enabled_flag': 1},
+          ),
+          isTrue,
+        );
+        expect(
+          DependsOnEvaluator.evaluate(
+            'eval:doc.enabled_flag == 1;',
+            {'enabled_flag': 0},
+          ),
+          isFalse,
+        );
+      });
+
+      test('trailing semicolon on string comparison is stripped', () {
+        expect(
+          DependsOnEvaluator.evaluate(
+            "eval:doc.status == 'Yes';",
+            {'status': 'Yes'},
+          ),
+          isTrue,
+        );
+      });
     });
 
     group('.includes() array expressions', () {

--- a/test/link_field_test.dart
+++ b/test/link_field_test.dart
@@ -304,6 +304,40 @@ void main() {
       expect(find.text('Select state first'), findsNothing);
     });
 
+    // Regression: some link_filters wrap the dependency in a JS expression
+    // — e.g. `(doc.category||'').replace(/^prefix\s*/, '')` — instead of a
+    // bare `eval:doc.x`. Before the fix, extractEvalDocField failed to
+    // recognize `category` as a dependency at all, so leaving it blank fell
+    // through to a bare "No options available" instead of prompting the
+    // user to fill it in.
+    const kComplexLinkFilters =
+        '[["Other DocType","target_field","=",'
+        '"eval:(doc.category||\'\').replace(/^prefix\\\\s*/, \'\')"]]';
+
+    testWidgets(
+      'recognizes dependent field inside a wrapped JS expression',
+      (tester) async {
+        final service = _FakeLinkOptionService();
+
+        await tester.pumpWidget(
+          _wrap(
+            LinkField(
+              field: _linkField(linkFilters: kComplexLinkFilters),
+              linkOptionService: service,
+              formData: {}, // category left blank
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(
+          find.text('Select category first'),
+          findsAtLeastNWidgets(1),
+        );
+        expect(find.text('No options available'), findsNothing);
+      },
+    );
+
     testWidgets('options load when dependent field value is filled in', (
       tester,
     ) async {

--- a/test/ui/widgets/fields/select_field_test.dart
+++ b/test/ui/widgets/fields/select_field_test.dart
@@ -130,6 +130,29 @@ void main() {
       );
       expect(w.enabled, isFalse);
     });
+
+    testWidgets(
+      'readOnly with valid options still renders all options, not the '
+      'no-options placeholder',
+      (tester) async {
+        await _pumpSelect(
+          tester,
+          field: DocField(
+            fieldname: 'month',
+            fieldtype: 'Select',
+            label: 'Month',
+            options: '\nJanuary\nFebruary\nMarch',
+            readOnly: true,
+          ),
+        );
+        expect(find.text('No options available'), findsNothing);
+        final w = tester.widget<FormBuilderDropdown<String>>(
+          find.byType(FormBuilderDropdown<String>),
+        );
+        expect(w.enabled, isFalse);
+        expect(w.items.length, 3);
+      },
+    );
   });
 
   group('empty-options fallback', () {


### PR DESCRIPTION
## Summary

Two small, additive fixes surfaced while building an offline-first mobile app on this SDK:

1. **`DependsOnEvaluator` parsing gaps** (closes #84)
   - `_extractValue` now strips a trailing `;` before literal parsing, so expressions like `eval:doc.x == 1;` compare correctly instead of always falling through to string comparison.
   - `extractEvalDocField` now falls back to a regex search for the first `doc.<field>` reference when the whole expression isn't a bare `doc.field` value (e.g. `eval:(doc.x||'').replace(/.../, '')`), so the dependent-field gate on Link fields with `link_filters` still works for these wrapped JS expressions.

2. **Child-table row Save button loading state** (closes #85)
   - `_ChildTableSheet`'s Save button now shows a small spinner instead of a bare disabled checkmark icon while waiting for the child form's `registerSubmit` callback to fire, so the button reads as "loading" rather than "broken."

3. **Regression test only** — locks in that `SelectField` with `readOnly: true` and valid `options` already renders all options correctly (no code change, just coverage).

## Why

All three issues stem from `depends_on`/`link_filters` expression shapes and form-builder lifecycle timing that occur on real backends — none are Frappe-version-specific; the evaluator already fails safe (defaults to showing the field / no gating) when it can't parse an expression, and these changes only widen what's *recognized*, not the fallback behavior.

## Test plan

- [x] `flutter test` — full suite passes (1557/1557)
- [x] `flutter analyze` — no new issues in `lib/` or `test/`
- [x] Added regression tests for both `DependsOnEvaluator` fixes and the wrapped-JS `link_filters` case
- [x] Added a regression guard proving `SelectField` readOnly + valid options was already correct

Closes #84, closes #85.