### PR TITLE
chore(release): set version to 2.0.0-beta for pub.dev prerelease

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: frappe_mobile_sdk_example
 description: Example app demonstrating Frappe Mobile SDK usage
 publish_to: 'none'
 
-version: 2.0.0-beta.1+1
+version: 2.0.0-beta
 
 environment:
   sdk: ^3.10.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: frappe_mobile_sdk
 description: Flutter SDK for offline-first Frappe/ERPNext mobile apps with auth, API access, dynamic forms, and sync-aware local data operations.
-version: 2.0.0-beta.1+1
+version: 2.0.0-beta
 homepage: https://github.com/dhwani-ris/frappe-mobile-sdk
 repository: https://github.com/dhwani-ris/frappe-mobile-sdk
 issue_tracker: https://github.com/dhwani-ris/frappe-mobile-sdk/issues


### PR DESCRIPTION
## Align pubspec with the intended `v2.0.0-beta` pub.dev release

Two lines only — `pubspec.yaml` and `example/pubspec.yaml`:

```
- version: 2.0.0-beta.1+1
+ version: 2.0.0-beta
```

### Why

The pub.dev version is read from `pubspec.yaml`, **not** from the git tag. Publishing while the pubspec said `2.0.0-beta.1+1` would put `2.0.0-beta.1` on pub.dev under a tag named `v2.0.0-beta` — reintroducing the tag/pubspec mismatch this release is cleaning up.

- `+1` build metadata is ignored by pub.dev for version resolution and is discouraged in published packages.
- Plain `2.0.0-beta` leaves room for `2.0.0-beta.1` / `.2` later: semver orders `2.0.0-beta` < `2.0.0-beta.1`.
- `example/pubspec.yaml` is `publish_to: 'none'`, so its version is cosmetic — kept in step to avoid drift, and it is a `@semantic-release/git` asset.

### Release-bot safety

`chore:` prefix is deliberate. `.releaserc` sets `{"type":"chore","release":false}`, so this commit cannot trigger a release. `release.yml` fires only on `push` to `main`/`master`, so landing on `develop` triggers nothing regardless.

### Context — mForm launch, step 2 of 3

Intended end state: `v2.0.0-beta` published as a **pre-release**, with **`v1.2.0` remaining latest stable** so nobody picks up the beta by accident.

For the record on what already happened: merging #102 to `main` let `semantic-release` compute a *minor* bump from commit types (12 `feat`, zero `BREAKING CHANGE`/`!:` markers), overwrite the pubspec to `1.3.0`, and publish **`v1.3.0` as stable Latest** — not the intended pre-release. That GitHub release has since been demoted to pre-release and Latest is back to `v1.2.0`.

**pub.dev was never affected** — versions there are still `1.0.0, 1.1.0, 1.1.1, 1.2.0` (latest `1.2.0`), because the workflow has no publish step. Nothing needs retracting.

### Still open (not in this PR)

- `main`'s pubspec still reads `1.3.0` from the bot's commit.
- `.releaserc` has **no prerelease lane** (`branches: ["main","master"]`), so an intentional pre-release cannot be published by the automation. This will recur when plain `2.0.0` is cut.
