### PR TITLE
fix(pubspec): declare Flutter SDK constraint so the package can be published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - Unreleased
+## [2.0.0-beta] - 2026-07-30
 
 Major release: offline-first foundation, server-driven offline-mode toggle, and a new query/sync surface. Upgrades from `1.x` use a single transactional migration from database schema v2 to v3.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ platforms:
 
 environment:
   sdk: ">=3.10.4 <4.0.0"
+  flutter: ">=1.10.0"
 
 dependencies:
   flutter:
@@ -93,6 +94,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+
+  # imported by test/api/attachment_service_test.dart
+  path_provider_platform_interface: ^2.1.2
 
   # Pre-commit: format + analyze before commit (run: dart run flutter_pre_commit)
   flutter_pre_commit: ^0.2.4


### PR DESCRIPTION
## `frappe_mobile_sdk` could not be published to pub.dev — hard validation error

`flutter pub publish --dry-run` on `v2.0.0-beta` failed outright:

```
Package validation found the following error:
* pubspec.yaml allows Flutter SDK version 1.9.x, which does not support
  the flutter.plugin.platforms key.
  Please consider increasing the Flutter SDK requirement to ^1.10.0
```

### Cause

The package declares a real Flutter plugin:

```yaml
flutter:
  plugin:
    platforms:
      android:
        package: com.dhwaniris.frappe_mobile_sdk
        pluginClass: FrappeSecurityPlugin
      ios:
        pluginClass: FrappeSecurityPlugin
```

…but `environment:` constrained **only** the Dart SDK:

```yaml
environment:
  sdk: ">=3.10.4 <4.0.0"
```

With no `flutter:` bound, pub treats the allowed Flutter SDK as unbounded-low (1.9.x), which predates `flutter.plugin.platforms` support — hence the error. This is why **no 2.x has ever reached pub.dev**; it would have blocked any prior attempt too.

### Fix

```yaml
environment:
  sdk: ">=3.10.4 <4.0.0"
  flutter: ">=1.10.0"
```

`>=1.10.0` is the floor pub's own message recommends. Deliberately loose rather than "accurate": the real floor is already enforced by `sdk: ">=3.10.4"`, so this **does not narrow the supported consumer set**. A tighter bound like `>=3.10.0` would risk excluding resolvable consumers for no gain.

### Also clears the two other publish warnings

- **CHANGELOG** heading was `## [2.0.0] - Unreleased`, which doesn't name the version being published → now `## [2.0.0-beta] - 2026-07-30`. Content untouched.
- **`path_provider_platform_interface`** is imported directly by `test/api/attachment_service_test.dart` but was only a transitive dep → added to `dev_dependencies` at the resolved `^2.1.2`.

### Verification

`flutter pub publish --dry-run` re-run after these changes: **error gone**, `Package has 2 warnings` — the uncommitted-files warning (resolved by this commit) and the pre-existing `pubspec.lock` checked-in-while-gitignored notice, left alone as benign.

### Note — not fixed here

`pubspec.lock` is tracked but matched by `.gitignore`. Harmless; fixing it means a `.pubignore` or `.gitignore` change that's out of scope for unblocking this release.

Once merged, `v2.0.0-beta` gets re-pointed at the merge commit so the tag matches exactly what is published to pub.dev.
